### PR TITLE
rename errorMessage with an assertJ name

### DIFF
--- a/src/main/java/org/assertj/assertions/generator/AssertionGenerator.java
+++ b/src/main/java/org/assertj/assertions/generator/AssertionGenerator.java
@@ -57,9 +57,9 @@ public interface AssertionGenerator {
    *     // check that actual Race we want to make assertions on is not null.
    *     isNotNull();
    *     // we overrides the default error message with a more explicit one
-   *     String errorMessage = format("Expected Race's name to be <%s> but was <%s>", name, actual.getName());
+   *     String assertjErrorMessage = format("Expected Race's name to be <%s> but was <%s>", name, actual.getName());
    *     // check
-   *     if (!actual.getName().equals(name)) { throw new AssertionError(errorMessage); }
+   *     if (!actual.getName().equals(name)) { throw new AssertionError(assertjErrorMessage); }
    *
    *     // return the current assertion for method chaining
    *     return this;
@@ -69,9 +69,9 @@ public interface AssertionGenerator {
    *     // check that actual Race we want to make assertions on is not null.
    *     isNotNull();
    *     // we overrides the default error message with a more explicit one
-   *     String errorMessage = format("Expected actual Race to be immortal but was not.", actual);
+   *     String assertjErrorMessage = format("Expected actual Race to be immortal but was not.", actual);
    *     // check
-   *     if (!actual.isImmortal()) throw new AssertionError(errorMessage);
+   *     if (!actual.isImmortal()) throw new AssertionError(assertjErrorMessage);
    *     // return the current assertion for method chaining
    *     return this;
    *   }
@@ -132,9 +132,9 @@ public interface AssertionGenerator {
    *     // check that actual Race we want to make assertions on is not null.
    *     isNotNull();
    *     // we overrides the default error message with a more explicit one
-   *     String errorMessage = format("Expected Race's name to be <%s> but was <%s>", name, actual.getName());
+   *     String assertjErrorMessage = format("Expected Race's name to be <%s> but was <%s>", name, actual.getName());
    *     // check
-   *     if (!actual.getName().equals(name)) { throw new AssertionError(errorMessage); }
+   *     if (!actual.getName().equals(name)) { throw new AssertionError(assertjErrorMessage); }
    *
    *     // return the current assertion for method chaining
    *     return this;
@@ -144,9 +144,9 @@ public interface AssertionGenerator {
    *     // check that actual Race we want to make assertions on is not null.
    *     isNotNull();
    *     // we overrides the default error message with a more explicit one
-   *     String errorMessage = format("Expected actual Race to be immortal but was not.", actual);
+   *     String assertjErrorMessage = format("Expected actual Race to be immortal but was not.", actual);
    *     // check
-   *     if (!actual.isImmortal()) throw new AssertionError(errorMessage);
+   *     if (!actual.isImmortal()) throw new AssertionError(assertjErrorMessage);
    *     // return the current assertion for method chaining
    *     return this;
    *   }

--- a/src/main/java/org/assertj/assertions/generator/Template.java
+++ b/src/main/java/org/assertj/assertions/generator/Template.java
@@ -35,10 +35,10 @@ import org.apache.commons.lang3.CharEncoding;
  *   isNotNull();
  * 
  *   // we overrides the default error message with a more explicit one
- *   String errorMessage = format("Expected ${class_to_assert}'s ${property} to be <%s> but was <%s>", ${property}, actual.get${Property}());
+ *   String assertjErrorMessage = format("Expected ${class_to_assert}'s ${property} to be <%s> but was <%s>", ${property}, actual.get${Property}());
  *   
  *   // check
- *   if (!actual.get${Property}().equals(${property})) { throw new AssertionError(errorMessage); }
+ *   if (!actual.get${Property}().equals(${property})) { throw new AssertionError(assertjErrorMessage); }
  * 
  *   // return the current assertion for method chaining
  *   return this;

--- a/src/main/resources/templates/has_assertion_template.txt
+++ b/src/main/resources/templates/has_assertion_template.txt
@@ -10,12 +10,12 @@
     isNotNull();
 
     // overrides the default error message with a more explicit one
-    String errorMessage = "\nExpected ${property} of:\n  <%s>\nto be:\n  <%s>\nbut was:\n  <%s>";
+    String assertjErrorMessage = "\nExpected ${property} of:\n  <%s>\nto be:\n  <%s>\nbut was:\n  <%s>";
     
     // null safe check
     ${propertyType} actual${Property} = actual.get${Property}();
     if (!org.assertj.core.util.Objects.areEqual(actual${Property}, ${property})) {
-      failWithMessage(errorMessage, actual, ${property}, actual${Property});
+      failWithMessage(assertjErrorMessage, actual, ${property}, actual${Property});
     }
 
     // return the current assertion for method chaining

--- a/src/main/resources/templates/has_assertion_template_for_primitive.txt
+++ b/src/main/resources/templates/has_assertion_template_for_primitive.txt
@@ -10,12 +10,12 @@
     isNotNull();
 
     // overrides the default error message with a more explicit one
-    String errorMessage = "\nExpected ${property} of:\n  <%s>\nto be:\n  <%s>\nbut was:\n  <%s>";
+    String assertjErrorMessage = "\nExpected ${property} of:\n  <%s>\nto be:\n  <%s>\nbut was:\n  <%s>";
     
     // check
     ${propertyType} actual${Property} = actual.get${Property}();
     if (actual${Property} != ${property}) {
-      failWithMessage(errorMessage, actual, ${property}, actual${Property});
+      failWithMessage(assertjErrorMessage, actual, ${property}, actual${Property});
     }
 
     // return the current assertion for method chaining

--- a/src/main/resources/templates/has_elements_assertion_template_for_array.txt
+++ b/src/main/resources/templates/has_elements_assertion_template_for_array.txt
@@ -34,11 +34,11 @@
     isNotNull();
 
     // we override the default error message with a more explicit one
-    String errorMessage = "\nExpected :\n  <%s>\nnot to have ${property} but had :\n  <%s>";
+    String assertjErrorMessage = "\nExpected :\n  <%s>\nnot to have ${property} but had :\n  <%s>";
     
     // check
     if (actual.get${Property}().length > 0)  {
-      failWithMessage(errorMessage, actual, java.util.Arrays.toString(actual.get${Property}()));
+      failWithMessage(assertjErrorMessage, actual, java.util.Arrays.toString(actual.get${Property}()));
     }
     
     // return the current assertion for method chaining

--- a/src/main/resources/templates/has_elements_assertion_template_for_iterable.txt
+++ b/src/main/resources/templates/has_elements_assertion_template_for_iterable.txt
@@ -34,11 +34,11 @@
     isNotNull();
 
     // we override the default error message with a more explicit one
-    String errorMessage = "\nExpected :\n  <%s>\nnot to have ${property} but had :\n  <%s>";
+    String assertjErrorMessage = "\nExpected :\n  <%s>\nnot to have ${property} but had :\n  <%s>";
     
     // check
     if (!actual.get${Property}().isEmpty()) {
-      failWithMessage(errorMessage, actual, actual.get${Property}());
+      failWithMessage(assertjErrorMessage, actual, actual.get${Property}());
     }
     
     // return the current assertion for method chaining

--- a/src/test/resources/BeanWithOneException.expected.txt
+++ b/src/test/resources/BeanWithOneException.expected.txt
@@ -66,11 +66,11 @@ public class BeanWithOneExceptionAssert extends AbstractAssert<BeanWithOneExcept
     isNotNull();
 
     // we override the default error message with a more explicit one
-    String errorMessage = "\nExpected :\n  <%s>\nnot to have arrayPropertyThrowsException but had :\n  <%s>";
+    String assertjErrorMessage = "\nExpected :\n  <%s>\nnot to have arrayPropertyThrowsException but had :\n  <%s>";
     
     // check
     if (actual.getArrayPropertyThrowsException().length > 0)  {
-      failWithMessage(errorMessage, actual, java.util.Arrays.toString(actual.getArrayPropertyThrowsException()));
+      failWithMessage(assertjErrorMessage, actual, java.util.Arrays.toString(actual.getArrayPropertyThrowsException()));
     }
     
     // return the current assertion for method chaining
@@ -153,11 +153,11 @@ public class BeanWithOneExceptionAssert extends AbstractAssert<BeanWithOneExcept
     isNotNull();
 
     // we override the default error message with a more explicit one
-    String errorMessage = "\nExpected :\n  <%s>\nnot to have iterablePropertyThrowsException but had :\n  <%s>";
+    String assertjErrorMessage = "\nExpected :\n  <%s>\nnot to have iterablePropertyThrowsException but had :\n  <%s>";
     
     // check
     if (!actual.getIterablePropertyThrowsException().isEmpty()) {
-      failWithMessage(errorMessage, actual, actual.getIterablePropertyThrowsException());
+      failWithMessage(assertjErrorMessage, actual, actual.getIterablePropertyThrowsException());
     }
     
     // return the current assertion for method chaining
@@ -177,12 +177,12 @@ public class BeanWithOneExceptionAssert extends AbstractAssert<BeanWithOneExcept
     isNotNull();
 
     // overrides the default error message with a more explicit one
-    String errorMessage = "\nExpected stringPropertyThrowsException of:\n  <%s>\nto be:\n  <%s>\nbut was:\n  <%s>";
+    String assertjErrorMessage = "\nExpected stringPropertyThrowsException of:\n  <%s>\nto be:\n  <%s>\nbut was:\n  <%s>";
     
     // null safe check
     String actualStringPropertyThrowsException = actual.getStringPropertyThrowsException();
     if (!org.assertj.core.util.Objects.areEqual(actualStringPropertyThrowsException, stringPropertyThrowsException)) {
-      failWithMessage(errorMessage, actual, stringPropertyThrowsException, actualStringPropertyThrowsException);
+      failWithMessage(assertjErrorMessage, actual, stringPropertyThrowsException, actualStringPropertyThrowsException);
     }
 
     // return the current assertion for method chaining

--- a/src/test/resources/NestedClassAssert.template.expected.txt
+++ b/src/test/resources/NestedClassAssert.template.expected.txt
@@ -39,12 +39,12 @@ public class ${nestedClass}Assert extends AbstractAssert<${nestedClass}Assert, $
     isNotNull();
 
     // overrides the default error message with a more explicit one
-    String errorMessage = "\nExpected name of:\n  <%s>\nto be:\n  <%s>\nbut was:\n  <%s>";
+    String assertjErrorMessage = "\nExpected name of:\n  <%s>\nto be:\n  <%s>\nbut was:\n  <%s>";
     
     // null safe check
     String actualName = actual.getName();
     if (!org.assertj.core.util.Objects.areEqual(actualName, name)) {
-      failWithMessage(errorMessage, actual, name, actualName);
+      failWithMessage(assertjErrorMessage, actual, name, actualName);
     }
 
     // return the current assertion for method chaining

--- a/src/test/resources/PlayerAssert.expected.txt
+++ b/src/test/resources/PlayerAssert.expected.txt
@@ -39,12 +39,12 @@ public class PlayerAssert extends AbstractAssert<PlayerAssert, Player> {
     isNotNull();
 
     // overrides the default error message with a more explicit one
-    String errorMessage = "\nExpected assistsPerGame of:\n  <%s>\nto be:\n  <%s>\nbut was:\n  <%s>";
+    String assertjErrorMessage = "\nExpected assistsPerGame of:\n  <%s>\nto be:\n  <%s>\nbut was:\n  <%s>";
     
     // check
     int actualAssistsPerGame = actual.getAssistsPerGame();
     if (actualAssistsPerGame != assistsPerGame) {
-      failWithMessage(errorMessage, actual, assistsPerGame, actualAssistsPerGame);
+      failWithMessage(assertjErrorMessage, actual, assistsPerGame, actualAssistsPerGame);
     }
 
     // return the current assertion for method chaining
@@ -62,12 +62,12 @@ public class PlayerAssert extends AbstractAssert<PlayerAssert, Player> {
     isNotNull();
 
     // overrides the default error message with a more explicit one
-    String errorMessage = "\nExpected name of:\n  <%s>\nto be:\n  <%s>\nbut was:\n  <%s>";
+    String assertjErrorMessage = "\nExpected name of:\n  <%s>\nto be:\n  <%s>\nbut was:\n  <%s>";
     
     // null safe check
     Name actualName = actual.getName();
     if (!org.assertj.core.util.Objects.areEqual(actualName, name)) {
-      failWithMessage(errorMessage, actual, name, actualName);
+      failWithMessage(assertjErrorMessage, actual, name, actualName);
     }
 
     // return the current assertion for method chaining
@@ -109,11 +109,11 @@ public class PlayerAssert extends AbstractAssert<PlayerAssert, Player> {
     isNotNull();
 
     // we override the default error message with a more explicit one
-    String errorMessage = "\nExpected :\n  <%s>\nnot to have points but had :\n  <%s>";
+    String assertjErrorMessage = "\nExpected :\n  <%s>\nnot to have points but had :\n  <%s>";
     
     // check
     if (!actual.getPoints().isEmpty()) {
-      failWithMessage(errorMessage, actual, actual.getPoints());
+      failWithMessage(assertjErrorMessage, actual, actual.getPoints());
     }
     
     // return the current assertion for method chaining
@@ -132,12 +132,12 @@ public class PlayerAssert extends AbstractAssert<PlayerAssert, Player> {
     isNotNull();
 
     // overrides the default error message with a more explicit one
-    String errorMessage = "\nExpected pointsPerGame of:\n  <%s>\nto be:\n  <%s>\nbut was:\n  <%s>";
+    String assertjErrorMessage = "\nExpected pointsPerGame of:\n  <%s>\nto be:\n  <%s>\nbut was:\n  <%s>";
     
     // check
     int actualPointsPerGame = actual.getPointsPerGame();
     if (actualPointsPerGame != pointsPerGame) {
-      failWithMessage(errorMessage, actual, pointsPerGame, actualPointsPerGame);
+      failWithMessage(assertjErrorMessage, actual, pointsPerGame, actualPointsPerGame);
     }
 
     // return the current assertion for method chaining
@@ -179,11 +179,11 @@ public class PlayerAssert extends AbstractAssert<PlayerAssert, Player> {
     isNotNull();
 
     // we override the default error message with a more explicit one
-    String errorMessage = "\nExpected :\n  <%s>\nnot to have previousTeams but had :\n  <%s>";
+    String assertjErrorMessage = "\nExpected :\n  <%s>\nnot to have previousTeams but had :\n  <%s>";
     
     // check
     if (actual.getPreviousTeams().length > 0)  {
-      failWithMessage(errorMessage, actual, java.util.Arrays.toString(actual.getPreviousTeams()));
+      failWithMessage(assertjErrorMessage, actual, java.util.Arrays.toString(actual.getPreviousTeams()));
     }
     
     // return the current assertion for method chaining
@@ -202,12 +202,12 @@ public class PlayerAssert extends AbstractAssert<PlayerAssert, Player> {
     isNotNull();
 
     // overrides the default error message with a more explicit one
-    String errorMessage = "\nExpected reboundsPerGame of:\n  <%s>\nto be:\n  <%s>\nbut was:\n  <%s>";
+    String assertjErrorMessage = "\nExpected reboundsPerGame of:\n  <%s>\nto be:\n  <%s>\nbut was:\n  <%s>";
     
     // check
     int actualReboundsPerGame = actual.getReboundsPerGame();
     if (actualReboundsPerGame != reboundsPerGame) {
-      failWithMessage(errorMessage, actual, reboundsPerGame, actualReboundsPerGame);
+      failWithMessage(assertjErrorMessage, actual, reboundsPerGame, actualReboundsPerGame);
     }
 
     // return the current assertion for method chaining
@@ -261,12 +261,12 @@ public class PlayerAssert extends AbstractAssert<PlayerAssert, Player> {
     isNotNull();
 
     // overrides the default error message with a more explicit one
-    String errorMessage = "\nExpected team of:\n  <%s>\nto be:\n  <%s>\nbut was:\n  <%s>";
+    String assertjErrorMessage = "\nExpected team of:\n  <%s>\nto be:\n  <%s>\nbut was:\n  <%s>";
     
     // null safe check
     String actualTeam = actual.getTeam();
     if (!org.assertj.core.util.Objects.areEqual(actualTeam, team)) {
-      failWithMessage(errorMessage, actual, team, actualTeam);
+      failWithMessage(assertjErrorMessage, actual, team, actualTeam);
     }
 
     // return the current assertion for method chaining
@@ -308,11 +308,11 @@ public class PlayerAssert extends AbstractAssert<PlayerAssert, Player> {
     isNotNull();
 
     // we override the default error message with a more explicit one
-    String errorMessage = "\nExpected :\n  <%s>\nnot to have teamMates but had :\n  <%s>";
+    String assertjErrorMessage = "\nExpected :\n  <%s>\nnot to have teamMates but had :\n  <%s>";
     
     // check
     if (!actual.getTeamMates().isEmpty()) {
-      failWithMessage(errorMessage, actual, actual.getTeamMates());
+      failWithMessage(assertjErrorMessage, actual, actual.getTeamMates());
     }
     
     // return the current assertion for method chaining


### PR DESCRIPTION
Hi,

I have a bean : 

``` java
public class SessionBean {

    /**
     * sessionKey opened on my  awesome service.
     */
    private String sessionKey;

    /**
     * url of my awesome service.
     */
    private String url;

    /**
     * Error message if any.
     */
    private String errorMessage;
}
```

and the generated file contains:

``` java
    public SessionBeanAssert hasErrorMessage(String errorMessage)
    {
        // check that actual SessionBean we want to make assertions on is not null.
        isNotNull();

        // we overrides the default error message with a more explicit one
        String errorMessage = "\nExpected errorMessage of:\n  <%s>\nto be:\n  <%s>\n but was:\n  <%s>";

        // check
        if (!actual.getErrorMessage().equals(errorMessage)) {
            failWithMessage(errorMessage, actual, errorMessage, actual.getErrorMessage());
        }

        // return the current assertion for method chaining
        return this;
    }
```

with a compilation error.

I propose to rename the internal field with an assertj name.
