### PR TITLE
Tweak to omit unnecessary import and include all imports in the sort.

### DIFF
--- a/src/main/resources/templates/custom_assertion_class_template.txt
+++ b/src/main/resources/templates/custom_assertion_class_template.txt
@@ -1,8 +1,5 @@
 package ${package};
 
-import org.assertj.core.api.AbstractAssert;
-// Assertions is needed if an assertion for Iterable is generated
-import org.assertj.core.api.Assertions;
 ${imports}
 
 /**

--- a/src/test/resources/BeanWithOneException.expected.txt
+++ b/src/test/resources/BeanWithOneException.expected.txt
@@ -1,9 +1,8 @@
 package org.assertj.assertions.generator.data;
 
-import org.assertj.core.api.AbstractAssert;
-// Assertions is needed if an assertion for Iterable is generated
-import org.assertj.core.api.Assertions;
 import java.io.IOException;
+import org.assertj.core.api.AbstractAssert;
+import org.assertj.core.api.Assertions;
 
 
 /**

--- a/src/test/resources/NestedClassAssert.template.expected.txt
+++ b/src/test/resources/NestedClassAssert.template.expected.txt
@@ -1,8 +1,6 @@
 package org.assertj.assertions.generator.data;
 
 import org.assertj.core.api.AbstractAssert;
-// Assertions is needed if an assertion for Iterable is generated
-import org.assertj.core.api.Assertions;
 
 
 /**

--- a/src/test/resources/PlayerAssert.expected.txt
+++ b/src/test/resources/PlayerAssert.expected.txt
@@ -1,7 +1,6 @@
 package org.assertj.assertions.generator.data;
 
 import org.assertj.core.api.AbstractAssert;
-// Assertions is needed if an assertion for Iterable is generated
 import org.assertj.core.api.Assertions;
 
 


### PR DESCRIPTION
Because I am a bit of a neat freak when it comes to removing unnecessary lines from my code such as unused imports, I have made a slight tweak to the assertions generator so that if a generated class does not use the core Assertions class it will not be imported. It also includes all imports in the Set so that they can be sorted together.
