### PR TITLE
Use imports instead of FQN #97

### DIFF
--- a/src/main/java/org/assertj/assertions/generator/description/ClassDescription.java
+++ b/src/main/java/org/assertj/assertions/generator/description/ClassDescription.java
@@ -60,7 +60,11 @@ public class ClassDescription implements Comparable<ClassDescription> {
   public String getClassNameWithOuterClassNotSeparatedByDots() {
     return classTypeName.getSimpleNameWithOuterClassNotSeparatedByDots();
   }
-  
+
+  public String getOuterClassName() {
+    return classTypeName.getOuterClassName();
+  }
+
   public String getPackageName() {
     return classTypeName.getPackageName();
   }

--- a/src/main/java/org/assertj/assertions/generator/description/TypeName.java
+++ b/src/main/java/org/assertj/assertions/generator/description/TypeName.java
@@ -47,6 +47,7 @@ public class TypeName implements Comparable<TypeName> {
   private String typeSimpleNameWithOuterClass;
   private String typeSimpleNameWithOuterClassNotSeparatedByDots;
   private String packageName;
+  private String outerClassName;
 
   public TypeName(String typeSimpleName, String packageName) {
     if (typeSimpleName == null) throw new IllegalArgumentException("type simple name should not be null");
@@ -82,6 +83,7 @@ public class TypeName implements Comparable<TypeName> {
     this.typeSimpleNameWithOuterClass = ClassUtil.getSimpleNameWithOuterClass(clazz);
     this.typeSimpleNameWithOuterClassNotSeparatedByDots = ClassUtil.getSimpleNameWithOuterClassNotSeparatedByDots(clazz);
     this.packageName = clazz.getPackage() == null ? NO_PACKAGE : clazz.getPackage().getName();
+    this.outerClassName = ClassUtil.getSimpleNameOuterClass(clazz);
   }
 
   public String getSimpleName() {
@@ -102,6 +104,10 @@ public class TypeName implements Comparable<TypeName> {
 
   private void setPackageName(String packageName) {
     this.packageName = packageName == null ? NO_PACKAGE : packageName;
+  }
+
+  public String getOuterClassName() {
+    return outerClassName;
   }
 
   public boolean isPrimitive() {

--- a/src/main/java/org/assertj/assertions/generator/util/ClassUtil.java
+++ b/src/main/java/org/assertj/assertions/generator/util/ClassUtil.java
@@ -478,16 +478,22 @@ public class ClassUtil {
   /**
    * Gets the simple name of the outer class, if the class is not nested then this is the same as
    * {@link Class#getSimpleName()}.
+   * <p>
+   * Example:
    *
-   * @param clazz
+   *  <pre>
+   *    OnlyOuter -> OnlyOuter
+   *    Outer.Inner -> Outer
+   *    Outer.Inner1.Inner2 -> Outer
+   *  </pre>
+   * @param clazz for which the outer class name should be found
    * @return see description
    */
   public static String getSimpleNameOuterClass(Class<?> clazz) {
     if (isNotNestedClass(clazz)) {
       return clazz.getSimpleName();
     }
-    String outerClassName = null;
-    outerClassName = clazz.getName();
+    String outerClassName = clazz.getName();
     outerClassName = outerClassName.substring(clazz.getPackage().getName().length() + 1);
     outerClassName = outerClassName.substring(0, outerClassName.indexOf('$'));
     return outerClassName;

--- a/src/main/java/org/assertj/assertions/generator/util/ClassUtil.java
+++ b/src/main/java/org/assertj/assertions/generator/util/ClassUtil.java
@@ -476,6 +476,24 @@ public class ClassUtil {
   }
 
   /**
+   * Gets the simple name of the outer class, if the class is not nested then this is the same as
+   * {@link Class#getSimpleName()}.
+   *
+   * @param clazz
+   * @return see description
+   */
+  public static String getSimpleNameOuterClass(Class<?> clazz) {
+    if (isNotNestedClass(clazz)) {
+      return clazz.getSimpleName();
+    }
+    String outerClassName = null;
+    outerClassName = clazz.getName();
+    outerClassName = outerClassName.substring(clazz.getPackage().getName().length() + 1);
+    outerClassName = outerClassName.substring(0, outerClassName.indexOf('$'));
+    return outerClassName;
+  }
+
+  /**
    * Gets the simple name of the class but, unlike {@link Class#getSimpleName()}, it includes the name of the outer
    * class when <code>clazz</code> is an inner class, both class names are concatenated.
    * <p>

--- a/src/main/resources/templates/auto_closeable_bdd_soft_assertions_entry_point_class_template.txt
+++ b/src/main/resources/templates/auto_closeable_bdd_soft_assertions_entry_point_class_template.txt
@@ -1,5 +1,6 @@
 package ${package};
 
+${imports}
 /**
  * A version of {@link BDDSoftAssertions} that uses try-with-resources statement to automatically call
  * {@link BDDSoftAssertions#assertAll()} so that you don't forget to.

--- a/src/main/resources/templates/auto_closeable_soft_assertions_entry_point_class_template.txt
+++ b/src/main/resources/templates/auto_closeable_soft_assertions_entry_point_class_template.txt
@@ -1,5 +1,6 @@
 package ${package};
 
+${imports}
 /**
  * A version of {@link SoftAssertions} that uses try-with-resources statement to automatically call
  * {@link SoftAssertions#assertAll()} so that you don't forget to.

--- a/src/main/resources/templates/bdd_assertions_entry_point_class_template.txt
+++ b/src/main/resources/templates/bdd_assertions_entry_point_class_template.txt
@@ -1,5 +1,6 @@
 package ${package};
 
+${imports}
 /**
  * Entry point for BDD assertions of different data types.
  */

--- a/src/main/resources/templates/bdd_soft_assertions_entry_point_class_template.txt
+++ b/src/main/resources/templates/bdd_soft_assertions_entry_point_class_template.txt
@@ -1,5 +1,6 @@
 package ${package};
 
+${imports}
 /**
  * Entry point for BDD soft assertions of different data types.
  */

--- a/src/main/resources/templates/junit_bdd_soft_assertions_entry_point_class_template.txt
+++ b/src/main/resources/templates/junit_bdd_soft_assertions_entry_point_class_template.txt
@@ -1,5 +1,6 @@
 package ${package};
 
+${imports}
 /**
  * Like {@link BDDSoftAssertions} but as a junit rule that takes care of calling
  * {@link SoftAssertions#assertAll() assertAll()} at the end of each test.

--- a/src/main/resources/templates/junit_soft_assertions_entry_point_class_template.txt
+++ b/src/main/resources/templates/junit_soft_assertions_entry_point_class_template.txt
@@ -1,5 +1,6 @@
 package ${package};
 
+${imports}
 /**
  * Like {@link SoftAssertions} but as a junit rule that takes care of calling
  * {@link SoftAssertions#assertAll() assertAll()} at the end of each test.

--- a/src/main/resources/templates/soft_assertions_entry_point_class_template.txt
+++ b/src/main/resources/templates/soft_assertions_entry_point_class_template.txt
@@ -1,5 +1,6 @@
 package ${package};
 
+${imports}
 /**
  * Entry point for soft assertions of different data types.
  */

--- a/src/main/resources/templates/standard_assertions_entry_point_class_template.txt
+++ b/src/main/resources/templates/standard_assertions_entry_point_class_template.txt
@@ -1,5 +1,6 @@
 package ${package};
 
+${imports}
 /**
  * Entry point for assertions of different data types. Each method in this class is a static factory for the
  * type-specific assertion objects.

--- a/src/test/java/org/assertj/assertions/generator/NestedClassesTest.java
+++ b/src/test/java/org/assertj/assertions/generator/NestedClassesTest.java
@@ -22,26 +22,31 @@ import org.junit.experimental.theories.DataPoint;
 public interface NestedClassesTest {
   @DataPoint
   public static final NestedClass SNC = new NestedClass(OuterClass.StaticNestedPerson.class,
-                                                        "OuterClass.StaticNestedPerson");
+                                                        "OuterClass.StaticNestedPerson", "OuterClass");
   @DataPoint
   public static final NestedClass SNC_SNC = new NestedClass(OuterClass.StaticNestedPerson.SNP_StaticNestedPerson.class,
-                                                            "OuterClass.StaticNestedPerson.SNP_StaticNestedPerson");
+                                                            "OuterClass.StaticNestedPerson.SNP_StaticNestedPerson",
+                                                            "OuterClass");
   @DataPoint
   public static final NestedClass SNC_IC = new NestedClass(OuterClass.StaticNestedPerson.SNP_InnerPerson.class,
-                                                           "OuterClass.StaticNestedPerson.SNP_InnerPerson");
+                                                           "OuterClass.StaticNestedPerson.SNP_InnerPerson",
+                                                           "OuterClass");
   @DataPoint
-  public static final NestedClass IC = new NestedClass(OuterClass.InnerPerson.class, "OuterClass.InnerPerson");
+  public static final NestedClass IC = new NestedClass(OuterClass.InnerPerson.class, "OuterClass.InnerPerson",
+                                                       "OuterClass");
   @DataPoint
   public static final NestedClass IC_IC = new NestedClass(OuterClass.InnerPerson.IP_InnerPerson.class,
-                                                          "OuterClass.InnerPerson.IP_InnerPerson");
+                                                          "OuterClass.InnerPerson.IP_InnerPerson", "OuterClass");
 
   public static class NestedClass {
     private final Class<?> nestedClass;
     private final String classNameWithOuterClass;
+    private final String outerClassName;
 
-    public NestedClass(Class<?> nestedClass, String classNameWithOuterClass) {
+    public NestedClass(Class<?> nestedClass, String classNameWithOuterClass, String outerClassName) {
       this.nestedClass = nestedClass;
       this.classNameWithOuterClass = classNameWithOuterClass;
+      this.outerClassName = outerClassName;
     }
 
     public String getClassNameWithOuterClass() {
@@ -54,6 +59,10 @@ public interface NestedClassesTest {
 
     public Class<?> getNestedClass() {
       return nestedClass;
+    }
+
+    public String getOuterClassName() {
+      return outerClassName;
     }
   }
 }

--- a/src/test/java/org/assertj/assertions/generator/util/ClassUtilTest.java
+++ b/src/test/java/org/assertj/assertions/generator/util/ClassUtilTest.java
@@ -17,6 +17,7 @@ import static org.assertj.assertions.generator.util.ClassUtil.declaredGetterMeth
 import static org.assertj.assertions.generator.util.ClassUtil.getClassesRelatedTo;
 import static org.assertj.assertions.generator.util.ClassUtil.getNegativePredicateFor;
 import static org.assertj.assertions.generator.util.ClassUtil.getPredicatePrefix;
+import static org.assertj.assertions.generator.util.ClassUtil.getSimpleNameOuterClass;
 import static org.assertj.assertions.generator.util.ClassUtil.getSimpleNameWithOuterClass;
 import static org.assertj.assertions.generator.util.ClassUtil.getSimpleNameWithOuterClassNotSeparatedByDots;
 import static org.assertj.assertions.generator.util.ClassUtil.getterMethodsOf;
@@ -212,6 +213,13 @@ public class ClassUtilTest implements NestedClassesTest {
   }
 
   @Theory
+  public void should_return_outer_class_name_for_nested_class(NestedClass nestedClass) {
+    String actualName = getSimpleNameOuterClass(nestedClass.getNestedClass());
+    assertThat(actualName).isEqualTo(nestedClass.getOuterClassName());
+  }
+
+
+  @Theory
   public void should_return_inner_class_name_with_outer_class_name_not_separated_by_dots(NestedClass nestedClass) {
     String actualName = getSimpleNameWithOuterClassNotSeparatedByDots(nestedClass.getNestedClass());
     assertThat(actualName).isEqualTo(nestedClass.getClassNameWithOuterClassNotSeparatedBytDots());
@@ -226,6 +234,11 @@ public class ClassUtilTest implements NestedClassesTest {
   @Test
   public void testGetSimpleNameWithOuterClass_notNestedClass() throws Exception {
     assertThat(ClassUtil.getSimpleNameWithOuterClass(String.class)).isEqualTo("String");
+  }
+
+  @Test
+  public void testGetSimpleNameOuterClass_notNestedClass() throws Exception {
+    assertThat(ClassUtil.getSimpleNameOuterClass(String.class)).isEqualTo("String");
   }
 
   @Test

--- a/src/test/resources/Assertions.expected.txt
+++ b/src/test/resources/Assertions.expected.txt
@@ -1,5 +1,23 @@
 package org.assertj.assertions.generator.data;
 
+import org.assertj.assertions.generator.data.ArtWork;
+import org.assertj.assertions.generator.data.ArtWorkAssert;
+import org.assertj.assertions.generator.data.Movie;
+import org.assertj.assertions.generator.data.MovieAssert;
+import org.assertj.assertions.generator.data.MoviePublicCategoryAssert;
+import org.assertj.assertions.generator.data.Name;
+import org.assertj.assertions.generator.data.NameAssert;
+import org.assertj.assertions.generator.data.TreeEnum;
+import org.assertj.assertions.generator.data.TreeEnumAssert;
+import org.assertj.assertions.generator.data.lotr.Race;
+import org.assertj.assertions.generator.data.lotr.RaceAssert;
+import org.assertj.assertions.generator.data.lotr.Ring;
+import org.assertj.assertions.generator.data.lotr.RingAssert;
+import org.assertj.assertions.generator.data.lotr.TolkienCharacter;
+import org.assertj.assertions.generator.data.lotr.TolkienCharacterAssert;
+import org.assertj.assertions.generator.data.nba.Player;
+import org.assertj.assertions.generator.data.nba.PlayerAssert;
+
 /**
  * Entry point for assertions of different data types. Each method in this class is a static factory for the
  * type-specific assertion objects.
@@ -8,102 +26,102 @@ package org.assertj.assertions.generator.data;
 public class Assertions {
 
   /**
-   * Creates a new instance of <code>{@link org.assertj.assertions.generator.data.ArtWorkAssert}</code>.
+   * Creates a new instance of <code>{@link ArtWorkAssert}</code>.
    *
    * @param actual the actual value.
    * @return the created assertion object.
    */
   @org.assertj.core.util.CheckReturnValue
-  public static org.assertj.assertions.generator.data.ArtWorkAssert assertThat(org.assertj.assertions.generator.data.ArtWork actual) {
-    return new org.assertj.assertions.generator.data.ArtWorkAssert(actual);
+  public static ArtWorkAssert assertThat(ArtWork actual) {
+    return new ArtWorkAssert(actual);
   }
 
   /**
-   * Creates a new instance of <code>{@link org.assertj.assertions.generator.data.MovieAssert}</code>.
+   * Creates a new instance of <code>{@link MovieAssert}</code>.
    *
    * @param actual the actual value.
    * @return the created assertion object.
    */
   @org.assertj.core.util.CheckReturnValue
-  public static org.assertj.assertions.generator.data.MovieAssert assertThat(org.assertj.assertions.generator.data.Movie actual) {
-    return new org.assertj.assertions.generator.data.MovieAssert(actual);
+  public static MovieAssert assertThat(Movie actual) {
+    return new MovieAssert(actual);
   }
 
   /**
-   * Creates a new instance of <code>{@link org.assertj.assertions.generator.data.MoviePublicCategoryAssert}</code>.
+   * Creates a new instance of <code>{@link MoviePublicCategoryAssert}</code>.
    *
    * @param actual the actual value.
    * @return the created assertion object.
    */
   @org.assertj.core.util.CheckReturnValue
-  public static org.assertj.assertions.generator.data.MoviePublicCategoryAssert assertThat(org.assertj.assertions.generator.data.Movie.PublicCategory actual) {
-    return new org.assertj.assertions.generator.data.MoviePublicCategoryAssert(actual);
+  public static MoviePublicCategoryAssert assertThat(Movie.PublicCategory actual) {
+    return new MoviePublicCategoryAssert(actual);
   }
 
   /**
-   * Creates a new instance of <code>{@link org.assertj.assertions.generator.data.NameAssert}</code>.
+   * Creates a new instance of <code>{@link NameAssert}</code>.
    *
    * @param actual the actual value.
    * @return the created assertion object.
    */
   @org.assertj.core.util.CheckReturnValue
-  public static org.assertj.assertions.generator.data.NameAssert assertThat(org.assertj.assertions.generator.data.Name actual) {
-    return new org.assertj.assertions.generator.data.NameAssert(actual);
+  public static NameAssert assertThat(Name actual) {
+    return new NameAssert(actual);
   }
 
   /**
-   * Creates a new instance of <code>{@link org.assertj.assertions.generator.data.TreeEnumAssert}</code>.
+   * Creates a new instance of <code>{@link TreeEnumAssert}</code>.
    *
    * @param actual the actual value.
    * @return the created assertion object.
    */
   @org.assertj.core.util.CheckReturnValue
-  public static org.assertj.assertions.generator.data.TreeEnumAssert assertThat(org.assertj.assertions.generator.data.TreeEnum actual) {
-    return new org.assertj.assertions.generator.data.TreeEnumAssert(actual);
+  public static TreeEnumAssert assertThat(TreeEnum actual) {
+    return new TreeEnumAssert(actual);
   }
 
   /**
-   * Creates a new instance of <code>{@link org.assertj.assertions.generator.data.lotr.RaceAssert}</code>.
+   * Creates a new instance of <code>{@link RaceAssert}</code>.
    *
    * @param actual the actual value.
    * @return the created assertion object.
    */
   @org.assertj.core.util.CheckReturnValue
-  public static org.assertj.assertions.generator.data.lotr.RaceAssert assertThat(org.assertj.assertions.generator.data.lotr.Race actual) {
-    return new org.assertj.assertions.generator.data.lotr.RaceAssert(actual);
+  public static RaceAssert assertThat(Race actual) {
+    return new RaceAssert(actual);
   }
 
   /**
-   * Creates a new instance of <code>{@link org.assertj.assertions.generator.data.lotr.RingAssert}</code>.
+   * Creates a new instance of <code>{@link RingAssert}</code>.
    *
    * @param actual the actual value.
    * @return the created assertion object.
    */
   @org.assertj.core.util.CheckReturnValue
-  public static org.assertj.assertions.generator.data.lotr.RingAssert assertThat(org.assertj.assertions.generator.data.lotr.Ring actual) {
-    return new org.assertj.assertions.generator.data.lotr.RingAssert(actual);
+  public static RingAssert assertThat(Ring actual) {
+    return new RingAssert(actual);
   }
 
   /**
-   * Creates a new instance of <code>{@link org.assertj.assertions.generator.data.lotr.TolkienCharacterAssert}</code>.
+   * Creates a new instance of <code>{@link TolkienCharacterAssert}</code>.
    *
    * @param actual the actual value.
    * @return the created assertion object.
    */
   @org.assertj.core.util.CheckReturnValue
-  public static org.assertj.assertions.generator.data.lotr.TolkienCharacterAssert assertThat(org.assertj.assertions.generator.data.lotr.TolkienCharacter actual) {
-    return new org.assertj.assertions.generator.data.lotr.TolkienCharacterAssert(actual);
+  public static TolkienCharacterAssert assertThat(TolkienCharacter actual) {
+    return new TolkienCharacterAssert(actual);
   }
 
   /**
-   * Creates a new instance of <code>{@link org.assertj.assertions.generator.data.nba.PlayerAssert}</code>.
+   * Creates a new instance of <code>{@link PlayerAssert}</code>.
    *
    * @param actual the actual value.
    * @return the created assertion object.
    */
   @org.assertj.core.util.CheckReturnValue
-  public static org.assertj.assertions.generator.data.nba.PlayerAssert assertThat(org.assertj.assertions.generator.data.nba.Player actual) {
-    return new org.assertj.assertions.generator.data.nba.PlayerAssert(actual);
+  public static PlayerAssert assertThat(Player actual) {
+    return new PlayerAssert(actual);
   }
 
   /**

--- a/src/test/resources/AssertionsForClassesWithSameName.expected.txt
+++ b/src/test/resources/AssertionsForClassesWithSameName.expected.txt
@@ -1,5 +1,8 @@
 package org;
 
+import org.assertj.assertions.generator.data.Team;
+import org.assertj.assertions.generator.data.TeamAssert;
+
 /**
  * Entry point for assertions of different data types. Each method in this class is a static factory for the
  * type-specific assertion objects.
@@ -8,14 +11,14 @@ package org;
 public class Assertions {
 
   /**
-   * Creates a new instance of <code>{@link org.assertj.assertions.generator.data.TeamAssert}</code>.
+   * Creates a new instance of <code>{@link TeamAssert}</code>.
    *
    * @param actual the actual value.
    * @return the created assertion object.
    */
   @org.assertj.core.util.CheckReturnValue
-  public static org.assertj.assertions.generator.data.TeamAssert assertThat(org.assertj.assertions.generator.data.Team actual) {
-    return new org.assertj.assertions.generator.data.TeamAssert(actual);
+  public static TeamAssert assertThat(Team actual) {
+    return new TeamAssert(actual);
   }
 
   /**

--- a/src/test/resources/AssertionsWithCustomPackage.expected.txt
+++ b/src/test/resources/AssertionsWithCustomPackage.expected.txt
@@ -1,5 +1,23 @@
 package my.custom.package;
 
+import org.assertj.assertions.generator.data.ArtWork;
+import org.assertj.assertions.generator.data.ArtWorkAssert;
+import org.assertj.assertions.generator.data.Movie;
+import org.assertj.assertions.generator.data.MovieAssert;
+import org.assertj.assertions.generator.data.MoviePublicCategoryAssert;
+import org.assertj.assertions.generator.data.Name;
+import org.assertj.assertions.generator.data.NameAssert;
+import org.assertj.assertions.generator.data.TreeEnum;
+import org.assertj.assertions.generator.data.TreeEnumAssert;
+import org.assertj.assertions.generator.data.lotr.Race;
+import org.assertj.assertions.generator.data.lotr.RaceAssert;
+import org.assertj.assertions.generator.data.lotr.Ring;
+import org.assertj.assertions.generator.data.lotr.RingAssert;
+import org.assertj.assertions.generator.data.lotr.TolkienCharacter;
+import org.assertj.assertions.generator.data.lotr.TolkienCharacterAssert;
+import org.assertj.assertions.generator.data.nba.Player;
+import org.assertj.assertions.generator.data.nba.PlayerAssert;
+
 /**
  * Entry point for assertions of different data types. Each method in this class is a static factory for the
  * type-specific assertion objects.
@@ -8,102 +26,102 @@ package my.custom.package;
 public class Assertions {
 
   /**
-   * Creates a new instance of <code>{@link org.assertj.assertions.generator.data.ArtWorkAssert}</code>.
+   * Creates a new instance of <code>{@link ArtWorkAssert}</code>.
    *
    * @param actual the actual value.
    * @return the created assertion object.
    */
   @org.assertj.core.util.CheckReturnValue
-  public static org.assertj.assertions.generator.data.ArtWorkAssert assertThat(org.assertj.assertions.generator.data.ArtWork actual) {
-    return new org.assertj.assertions.generator.data.ArtWorkAssert(actual);
+  public static ArtWorkAssert assertThat(ArtWork actual) {
+    return new ArtWorkAssert(actual);
   }
 
   /**
-   * Creates a new instance of <code>{@link org.assertj.assertions.generator.data.MovieAssert}</code>.
+   * Creates a new instance of <code>{@link MovieAssert}</code>.
    *
    * @param actual the actual value.
    * @return the created assertion object.
    */
   @org.assertj.core.util.CheckReturnValue
-  public static org.assertj.assertions.generator.data.MovieAssert assertThat(org.assertj.assertions.generator.data.Movie actual) {
-    return new org.assertj.assertions.generator.data.MovieAssert(actual);
+  public static MovieAssert assertThat(Movie actual) {
+    return new MovieAssert(actual);
   }
 
   /**
-   * Creates a new instance of <code>{@link org.assertj.assertions.generator.data.MoviePublicCategoryAssert}</code>.
+   * Creates a new instance of <code>{@link MoviePublicCategoryAssert}</code>.
    *
    * @param actual the actual value.
    * @return the created assertion object.
    */
   @org.assertj.core.util.CheckReturnValue
-  public static org.assertj.assertions.generator.data.MoviePublicCategoryAssert assertThat(org.assertj.assertions.generator.data.Movie.PublicCategory actual) {
-    return new org.assertj.assertions.generator.data.MoviePublicCategoryAssert(actual);
+  public static MoviePublicCategoryAssert assertThat(Movie.PublicCategory actual) {
+    return new MoviePublicCategoryAssert(actual);
   }
 
   /**
-   * Creates a new instance of <code>{@link org.assertj.assertions.generator.data.NameAssert}</code>.
+   * Creates a new instance of <code>{@link NameAssert}</code>.
    *
    * @param actual the actual value.
    * @return the created assertion object.
    */
   @org.assertj.core.util.CheckReturnValue
-  public static org.assertj.assertions.generator.data.NameAssert assertThat(org.assertj.assertions.generator.data.Name actual) {
-    return new org.assertj.assertions.generator.data.NameAssert(actual);
+  public static NameAssert assertThat(Name actual) {
+    return new NameAssert(actual);
   }
 
   /**
-   * Creates a new instance of <code>{@link org.assertj.assertions.generator.data.TreeEnumAssert}</code>.
+   * Creates a new instance of <code>{@link TreeEnumAssert}</code>.
    *
    * @param actual the actual value.
    * @return the created assertion object.
    */
   @org.assertj.core.util.CheckReturnValue
-  public static org.assertj.assertions.generator.data.TreeEnumAssert assertThat(org.assertj.assertions.generator.data.TreeEnum actual) {
-    return new org.assertj.assertions.generator.data.TreeEnumAssert(actual);
+  public static TreeEnumAssert assertThat(TreeEnum actual) {
+    return new TreeEnumAssert(actual);
   }
 
   /**
-   * Creates a new instance of <code>{@link org.assertj.assertions.generator.data.lotr.RaceAssert}</code>.
+   * Creates a new instance of <code>{@link RaceAssert}</code>.
    *
    * @param actual the actual value.
    * @return the created assertion object.
    */
   @org.assertj.core.util.CheckReturnValue
-  public static org.assertj.assertions.generator.data.lotr.RaceAssert assertThat(org.assertj.assertions.generator.data.lotr.Race actual) {
-    return new org.assertj.assertions.generator.data.lotr.RaceAssert(actual);
+  public static RaceAssert assertThat(Race actual) {
+    return new RaceAssert(actual);
   }
 
   /**
-   * Creates a new instance of <code>{@link org.assertj.assertions.generator.data.lotr.RingAssert}</code>.
+   * Creates a new instance of <code>{@link RingAssert}</code>.
    *
    * @param actual the actual value.
    * @return the created assertion object.
    */
   @org.assertj.core.util.CheckReturnValue
-  public static org.assertj.assertions.generator.data.lotr.RingAssert assertThat(org.assertj.assertions.generator.data.lotr.Ring actual) {
-    return new org.assertj.assertions.generator.data.lotr.RingAssert(actual);
+  public static RingAssert assertThat(Ring actual) {
+    return new RingAssert(actual);
   }
 
   /**
-   * Creates a new instance of <code>{@link org.assertj.assertions.generator.data.lotr.TolkienCharacterAssert}</code>.
+   * Creates a new instance of <code>{@link TolkienCharacterAssert}</code>.
    *
    * @param actual the actual value.
    * @return the created assertion object.
    */
   @org.assertj.core.util.CheckReturnValue
-  public static org.assertj.assertions.generator.data.lotr.TolkienCharacterAssert assertThat(org.assertj.assertions.generator.data.lotr.TolkienCharacter actual) {
-    return new org.assertj.assertions.generator.data.lotr.TolkienCharacterAssert(actual);
+  public static TolkienCharacterAssert assertThat(TolkienCharacter actual) {
+    return new TolkienCharacterAssert(actual);
   }
 
   /**
-   * Creates a new instance of <code>{@link org.assertj.assertions.generator.data.nba.PlayerAssert}</code>.
+   * Creates a new instance of <code>{@link PlayerAssert}</code>.
    *
    * @param actual the actual value.
    * @return the created assertion object.
    */
   @org.assertj.core.util.CheckReturnValue
-  public static org.assertj.assertions.generator.data.nba.PlayerAssert assertThat(org.assertj.assertions.generator.data.nba.Player actual) {
-    return new org.assertj.assertions.generator.data.nba.PlayerAssert(actual);
+  public static PlayerAssert assertThat(Player actual) {
+    return new PlayerAssert(actual);
   }
 
   /**

--- a/src/test/resources/AutoCloseableBDDSoftAssertions.expected.txt
+++ b/src/test/resources/AutoCloseableBDDSoftAssertions.expected.txt
@@ -1,5 +1,23 @@
 package org.assertj.assertions.generator.data;
 
+import org.assertj.assertions.generator.data.ArtWork;
+import org.assertj.assertions.generator.data.ArtWorkAssert;
+import org.assertj.assertions.generator.data.Movie;
+import org.assertj.assertions.generator.data.MovieAssert;
+import org.assertj.assertions.generator.data.MoviePublicCategoryAssert;
+import org.assertj.assertions.generator.data.Name;
+import org.assertj.assertions.generator.data.NameAssert;
+import org.assertj.assertions.generator.data.TreeEnum;
+import org.assertj.assertions.generator.data.TreeEnumAssert;
+import org.assertj.assertions.generator.data.lotr.Race;
+import org.assertj.assertions.generator.data.lotr.RaceAssert;
+import org.assertj.assertions.generator.data.lotr.Ring;
+import org.assertj.assertions.generator.data.lotr.RingAssert;
+import org.assertj.assertions.generator.data.lotr.TolkienCharacter;
+import org.assertj.assertions.generator.data.lotr.TolkienCharacterAssert;
+import org.assertj.assertions.generator.data.nba.Player;
+import org.assertj.assertions.generator.data.nba.PlayerAssert;
+
 /**
  * A version of {@link BDDSoftAssertions} that uses try-with-resources statement to automatically call
  * {@link BDDSoftAssertions#assertAll()} so that you don't forget to.
@@ -24,102 +42,102 @@ package org.assertj.assertions.generator.data;
 public class AutoCloseableBDDSoftAssertions extends org.assertj.core.api.BDDSoftAssertions implements AutoCloseable {
 
   /**
-   * Creates a new "soft" instance of <code>{@link org.assertj.assertions.generator.data.ArtWorkAssert}</code>.
+   * Creates a new "soft" instance of <code>{@link ArtWorkAssert}</code>.
    *
    * @param actual the actual value.
    * @return the created "soft" assertion object.
    */
   @org.assertj.core.util.CheckReturnValue
-  public org.assertj.assertions.generator.data.ArtWorkAssert then(org.assertj.assertions.generator.data.ArtWork actual) {
-    return proxy(org.assertj.assertions.generator.data.ArtWorkAssert.class, org.assertj.assertions.generator.data.ArtWork.class, actual);
+  public ArtWorkAssert then(ArtWork actual) {
+    return proxy(ArtWorkAssert.class, ArtWork.class, actual);
   }
 
   /**
-   * Creates a new "soft" instance of <code>{@link org.assertj.assertions.generator.data.MovieAssert}</code>.
+   * Creates a new "soft" instance of <code>{@link MovieAssert}</code>.
    *
    * @param actual the actual value.
    * @return the created "soft" assertion object.
    */
   @org.assertj.core.util.CheckReturnValue
-  public org.assertj.assertions.generator.data.MovieAssert then(org.assertj.assertions.generator.data.Movie actual) {
-    return proxy(org.assertj.assertions.generator.data.MovieAssert.class, org.assertj.assertions.generator.data.Movie.class, actual);
+  public MovieAssert then(Movie actual) {
+    return proxy(MovieAssert.class, Movie.class, actual);
   }
 
   /**
-   * Creates a new "soft" instance of <code>{@link org.assertj.assertions.generator.data.MoviePublicCategoryAssert}</code>.
+   * Creates a new "soft" instance of <code>{@link MoviePublicCategoryAssert}</code>.
    *
    * @param actual the actual value.
    * @return the created "soft" assertion object.
    */
   @org.assertj.core.util.CheckReturnValue
-  public org.assertj.assertions.generator.data.MoviePublicCategoryAssert then(org.assertj.assertions.generator.data.Movie.PublicCategory actual) {
-    return proxy(org.assertj.assertions.generator.data.MoviePublicCategoryAssert.class, org.assertj.assertions.generator.data.Movie.PublicCategory.class, actual);
+  public MoviePublicCategoryAssert then(Movie.PublicCategory actual) {
+    return proxy(MoviePublicCategoryAssert.class, Movie.PublicCategory.class, actual);
   }
 
   /**
-   * Creates a new "soft" instance of <code>{@link org.assertj.assertions.generator.data.NameAssert}</code>.
+   * Creates a new "soft" instance of <code>{@link NameAssert}</code>.
    *
    * @param actual the actual value.
    * @return the created "soft" assertion object.
    */
   @org.assertj.core.util.CheckReturnValue
-  public org.assertj.assertions.generator.data.NameAssert then(org.assertj.assertions.generator.data.Name actual) {
-    return proxy(org.assertj.assertions.generator.data.NameAssert.class, org.assertj.assertions.generator.data.Name.class, actual);
+  public NameAssert then(Name actual) {
+    return proxy(NameAssert.class, Name.class, actual);
   }
 
   /**
-   * Creates a new "soft" instance of <code>{@link org.assertj.assertions.generator.data.TreeEnumAssert}</code>.
+   * Creates a new "soft" instance of <code>{@link TreeEnumAssert}</code>.
    *
    * @param actual the actual value.
    * @return the created "soft" assertion object.
    */
   @org.assertj.core.util.CheckReturnValue
-  public org.assertj.assertions.generator.data.TreeEnumAssert then(org.assertj.assertions.generator.data.TreeEnum actual) {
-    return proxy(org.assertj.assertions.generator.data.TreeEnumAssert.class, org.assertj.assertions.generator.data.TreeEnum.class, actual);
+  public TreeEnumAssert then(TreeEnum actual) {
+    return proxy(TreeEnumAssert.class, TreeEnum.class, actual);
   }
 
   /**
-   * Creates a new "soft" instance of <code>{@link org.assertj.assertions.generator.data.lotr.RaceAssert}</code>.
+   * Creates a new "soft" instance of <code>{@link RaceAssert}</code>.
    *
    * @param actual the actual value.
    * @return the created "soft" assertion object.
    */
   @org.assertj.core.util.CheckReturnValue
-  public org.assertj.assertions.generator.data.lotr.RaceAssert then(org.assertj.assertions.generator.data.lotr.Race actual) {
-    return proxy(org.assertj.assertions.generator.data.lotr.RaceAssert.class, org.assertj.assertions.generator.data.lotr.Race.class, actual);
+  public RaceAssert then(Race actual) {
+    return proxy(RaceAssert.class, Race.class, actual);
   }
 
   /**
-   * Creates a new "soft" instance of <code>{@link org.assertj.assertions.generator.data.lotr.RingAssert}</code>.
+   * Creates a new "soft" instance of <code>{@link RingAssert}</code>.
    *
    * @param actual the actual value.
    * @return the created "soft" assertion object.
    */
   @org.assertj.core.util.CheckReturnValue
-  public org.assertj.assertions.generator.data.lotr.RingAssert then(org.assertj.assertions.generator.data.lotr.Ring actual) {
-    return proxy(org.assertj.assertions.generator.data.lotr.RingAssert.class, org.assertj.assertions.generator.data.lotr.Ring.class, actual);
+  public RingAssert then(Ring actual) {
+    return proxy(RingAssert.class, Ring.class, actual);
   }
 
   /**
-   * Creates a new "soft" instance of <code>{@link org.assertj.assertions.generator.data.lotr.TolkienCharacterAssert}</code>.
+   * Creates a new "soft" instance of <code>{@link TolkienCharacterAssert}</code>.
    *
    * @param actual the actual value.
    * @return the created "soft" assertion object.
    */
   @org.assertj.core.util.CheckReturnValue
-  public org.assertj.assertions.generator.data.lotr.TolkienCharacterAssert then(org.assertj.assertions.generator.data.lotr.TolkienCharacter actual) {
-    return proxy(org.assertj.assertions.generator.data.lotr.TolkienCharacterAssert.class, org.assertj.assertions.generator.data.lotr.TolkienCharacter.class, actual);
+  public TolkienCharacterAssert then(TolkienCharacter actual) {
+    return proxy(TolkienCharacterAssert.class, TolkienCharacter.class, actual);
   }
 
   /**
-   * Creates a new "soft" instance of <code>{@link org.assertj.assertions.generator.data.nba.PlayerAssert}</code>.
+   * Creates a new "soft" instance of <code>{@link PlayerAssert}</code>.
    *
    * @param actual the actual value.
    * @return the created "soft" assertion object.
    */
   @org.assertj.core.util.CheckReturnValue
-  public org.assertj.assertions.generator.data.nba.PlayerAssert then(org.assertj.assertions.generator.data.nba.Player actual) {
-    return proxy(org.assertj.assertions.generator.data.nba.PlayerAssert.class, org.assertj.assertions.generator.data.nba.Player.class, actual);
+  public PlayerAssert then(Player actual) {
+    return proxy(PlayerAssert.class, Player.class, actual);
   }
 
   @Override

--- a/src/test/resources/AutoCloseableSoftAssertions.expected.txt
+++ b/src/test/resources/AutoCloseableSoftAssertions.expected.txt
@@ -1,5 +1,23 @@
 package org.assertj.assertions.generator.data;
 
+import org.assertj.assertions.generator.data.ArtWork;
+import org.assertj.assertions.generator.data.ArtWorkAssert;
+import org.assertj.assertions.generator.data.Movie;
+import org.assertj.assertions.generator.data.MovieAssert;
+import org.assertj.assertions.generator.data.MoviePublicCategoryAssert;
+import org.assertj.assertions.generator.data.Name;
+import org.assertj.assertions.generator.data.NameAssert;
+import org.assertj.assertions.generator.data.TreeEnum;
+import org.assertj.assertions.generator.data.TreeEnumAssert;
+import org.assertj.assertions.generator.data.lotr.Race;
+import org.assertj.assertions.generator.data.lotr.RaceAssert;
+import org.assertj.assertions.generator.data.lotr.Ring;
+import org.assertj.assertions.generator.data.lotr.RingAssert;
+import org.assertj.assertions.generator.data.lotr.TolkienCharacter;
+import org.assertj.assertions.generator.data.lotr.TolkienCharacterAssert;
+import org.assertj.assertions.generator.data.nba.Player;
+import org.assertj.assertions.generator.data.nba.PlayerAssert;
+
 /**
  * A version of {@link SoftAssertions} that uses try-with-resources statement to automatically call
  * {@link SoftAssertions#assertAll()} so that you don't forget to.
@@ -23,102 +41,102 @@ package org.assertj.assertions.generator.data;
 public class AutoCloseableSoftAssertions extends org.assertj.core.api.SoftAssertions implements AutoCloseable {
 
   /**
-   * Creates a new "soft" instance of <code>{@link org.assertj.assertions.generator.data.ArtWorkAssert}</code>.
+   * Creates a new "soft" instance of <code>{@link ArtWorkAssert}</code>.
    *
    * @param actual the actual value.
    * @return the created "soft" assertion object.
    */
   @org.assertj.core.util.CheckReturnValue
-  public org.assertj.assertions.generator.data.ArtWorkAssert assertThat(org.assertj.assertions.generator.data.ArtWork actual) {
-    return proxy(org.assertj.assertions.generator.data.ArtWorkAssert.class, org.assertj.assertions.generator.data.ArtWork.class, actual);
+  public ArtWorkAssert assertThat(ArtWork actual) {
+    return proxy(ArtWorkAssert.class, ArtWork.class, actual);
   }
 
   /**
-   * Creates a new "soft" instance of <code>{@link org.assertj.assertions.generator.data.MovieAssert}</code>.
+   * Creates a new "soft" instance of <code>{@link MovieAssert}</code>.
    *
    * @param actual the actual value.
    * @return the created "soft" assertion object.
    */
   @org.assertj.core.util.CheckReturnValue
-  public org.assertj.assertions.generator.data.MovieAssert assertThat(org.assertj.assertions.generator.data.Movie actual) {
-    return proxy(org.assertj.assertions.generator.data.MovieAssert.class, org.assertj.assertions.generator.data.Movie.class, actual);
+  public MovieAssert assertThat(Movie actual) {
+    return proxy(MovieAssert.class, Movie.class, actual);
   }
 
   /**
-   * Creates a new "soft" instance of <code>{@link org.assertj.assertions.generator.data.MoviePublicCategoryAssert}</code>.
+   * Creates a new "soft" instance of <code>{@link MoviePublicCategoryAssert}</code>.
    *
    * @param actual the actual value.
    * @return the created "soft" assertion object.
    */
   @org.assertj.core.util.CheckReturnValue
-  public org.assertj.assertions.generator.data.MoviePublicCategoryAssert assertThat(org.assertj.assertions.generator.data.Movie.PublicCategory actual) {
-    return proxy(org.assertj.assertions.generator.data.MoviePublicCategoryAssert.class, org.assertj.assertions.generator.data.Movie.PublicCategory.class, actual);
+  public MoviePublicCategoryAssert assertThat(Movie.PublicCategory actual) {
+    return proxy(MoviePublicCategoryAssert.class, Movie.PublicCategory.class, actual);
   }
 
   /**
-   * Creates a new "soft" instance of <code>{@link org.assertj.assertions.generator.data.NameAssert}</code>.
+   * Creates a new "soft" instance of <code>{@link NameAssert}</code>.
    *
    * @param actual the actual value.
    * @return the created "soft" assertion object.
    */
   @org.assertj.core.util.CheckReturnValue
-  public org.assertj.assertions.generator.data.NameAssert assertThat(org.assertj.assertions.generator.data.Name actual) {
-    return proxy(org.assertj.assertions.generator.data.NameAssert.class, org.assertj.assertions.generator.data.Name.class, actual);
+  public NameAssert assertThat(Name actual) {
+    return proxy(NameAssert.class, Name.class, actual);
   }
 
   /**
-   * Creates a new "soft" instance of <code>{@link org.assertj.assertions.generator.data.TreeEnumAssert}</code>.
+   * Creates a new "soft" instance of <code>{@link TreeEnumAssert}</code>.
    *
    * @param actual the actual value.
    * @return the created "soft" assertion object.
    */
   @org.assertj.core.util.CheckReturnValue
-  public org.assertj.assertions.generator.data.TreeEnumAssert assertThat(org.assertj.assertions.generator.data.TreeEnum actual) {
-    return proxy(org.assertj.assertions.generator.data.TreeEnumAssert.class, org.assertj.assertions.generator.data.TreeEnum.class, actual);
+  public TreeEnumAssert assertThat(TreeEnum actual) {
+    return proxy(TreeEnumAssert.class, TreeEnum.class, actual);
   }
 
   /**
-   * Creates a new "soft" instance of <code>{@link org.assertj.assertions.generator.data.lotr.RaceAssert}</code>.
+   * Creates a new "soft" instance of <code>{@link RaceAssert}</code>.
    *
    * @param actual the actual value.
    * @return the created "soft" assertion object.
    */
   @org.assertj.core.util.CheckReturnValue
-  public org.assertj.assertions.generator.data.lotr.RaceAssert assertThat(org.assertj.assertions.generator.data.lotr.Race actual) {
-    return proxy(org.assertj.assertions.generator.data.lotr.RaceAssert.class, org.assertj.assertions.generator.data.lotr.Race.class, actual);
+  public RaceAssert assertThat(Race actual) {
+    return proxy(RaceAssert.class, Race.class, actual);
   }
 
   /**
-   * Creates a new "soft" instance of <code>{@link org.assertj.assertions.generator.data.lotr.RingAssert}</code>.
+   * Creates a new "soft" instance of <code>{@link RingAssert}</code>.
    *
    * @param actual the actual value.
    * @return the created "soft" assertion object.
    */
   @org.assertj.core.util.CheckReturnValue
-  public org.assertj.assertions.generator.data.lotr.RingAssert assertThat(org.assertj.assertions.generator.data.lotr.Ring actual) {
-    return proxy(org.assertj.assertions.generator.data.lotr.RingAssert.class, org.assertj.assertions.generator.data.lotr.Ring.class, actual);
+  public RingAssert assertThat(Ring actual) {
+    return proxy(RingAssert.class, Ring.class, actual);
   }
 
   /**
-   * Creates a new "soft" instance of <code>{@link org.assertj.assertions.generator.data.lotr.TolkienCharacterAssert}</code>.
+   * Creates a new "soft" instance of <code>{@link TolkienCharacterAssert}</code>.
    *
    * @param actual the actual value.
    * @return the created "soft" assertion object.
    */
   @org.assertj.core.util.CheckReturnValue
-  public org.assertj.assertions.generator.data.lotr.TolkienCharacterAssert assertThat(org.assertj.assertions.generator.data.lotr.TolkienCharacter actual) {
-    return proxy(org.assertj.assertions.generator.data.lotr.TolkienCharacterAssert.class, org.assertj.assertions.generator.data.lotr.TolkienCharacter.class, actual);
+  public TolkienCharacterAssert assertThat(TolkienCharacter actual) {
+    return proxy(TolkienCharacterAssert.class, TolkienCharacter.class, actual);
   }
 
   /**
-   * Creates a new "soft" instance of <code>{@link org.assertj.assertions.generator.data.nba.PlayerAssert}</code>.
+   * Creates a new "soft" instance of <code>{@link PlayerAssert}</code>.
    *
    * @param actual the actual value.
    * @return the created "soft" assertion object.
    */
   @org.assertj.core.util.CheckReturnValue
-  public org.assertj.assertions.generator.data.nba.PlayerAssert assertThat(org.assertj.assertions.generator.data.nba.Player actual) {
-    return proxy(org.assertj.assertions.generator.data.nba.PlayerAssert.class, org.assertj.assertions.generator.data.nba.Player.class, actual);
+  public PlayerAssert assertThat(Player actual) {
+    return proxy(PlayerAssert.class, Player.class, actual);
   }
 
   @Override

--- a/src/test/resources/BDDSoftAssertions.expected.txt
+++ b/src/test/resources/BDDSoftAssertions.expected.txt
@@ -1,5 +1,23 @@
 package org.assertj.assertions.generator.data;
 
+import org.assertj.assertions.generator.data.ArtWork;
+import org.assertj.assertions.generator.data.ArtWorkAssert;
+import org.assertj.assertions.generator.data.Movie;
+import org.assertj.assertions.generator.data.MovieAssert;
+import org.assertj.assertions.generator.data.MoviePublicCategoryAssert;
+import org.assertj.assertions.generator.data.Name;
+import org.assertj.assertions.generator.data.NameAssert;
+import org.assertj.assertions.generator.data.TreeEnum;
+import org.assertj.assertions.generator.data.TreeEnumAssert;
+import org.assertj.assertions.generator.data.lotr.Race;
+import org.assertj.assertions.generator.data.lotr.RaceAssert;
+import org.assertj.assertions.generator.data.lotr.Ring;
+import org.assertj.assertions.generator.data.lotr.RingAssert;
+import org.assertj.assertions.generator.data.lotr.TolkienCharacter;
+import org.assertj.assertions.generator.data.lotr.TolkienCharacterAssert;
+import org.assertj.assertions.generator.data.nba.Player;
+import org.assertj.assertions.generator.data.nba.PlayerAssert;
+
 /**
  * Entry point for BDD soft assertions of different data types.
  */
@@ -7,102 +25,102 @@ package org.assertj.assertions.generator.data;
 public class BDDSoftAssertions extends org.assertj.core.api.BDDSoftAssertions {
 
   /**
-   * Creates a new "soft" instance of <code>{@link org.assertj.assertions.generator.data.ArtWorkAssert}</code>.
+   * Creates a new "soft" instance of <code>{@link ArtWorkAssert}</code>.
    *
    * @param actual the actual value.
    * @return the created "soft" assertion object.
    */
   @org.assertj.core.util.CheckReturnValue
-  public org.assertj.assertions.generator.data.ArtWorkAssert then(org.assertj.assertions.generator.data.ArtWork actual) {
-    return proxy(org.assertj.assertions.generator.data.ArtWorkAssert.class, org.assertj.assertions.generator.data.ArtWork.class, actual);
+  public ArtWorkAssert then(ArtWork actual) {
+    return proxy(ArtWorkAssert.class, ArtWork.class, actual);
   }
 
   /**
-   * Creates a new "soft" instance of <code>{@link org.assertj.assertions.generator.data.MovieAssert}</code>.
+   * Creates a new "soft" instance of <code>{@link MovieAssert}</code>.
    *
    * @param actual the actual value.
    * @return the created "soft" assertion object.
    */
   @org.assertj.core.util.CheckReturnValue
-  public org.assertj.assertions.generator.data.MovieAssert then(org.assertj.assertions.generator.data.Movie actual) {
-    return proxy(org.assertj.assertions.generator.data.MovieAssert.class, org.assertj.assertions.generator.data.Movie.class, actual);
+  public MovieAssert then(Movie actual) {
+    return proxy(MovieAssert.class, Movie.class, actual);
   }
 
   /**
-   * Creates a new "soft" instance of <code>{@link org.assertj.assertions.generator.data.MoviePublicCategoryAssert}</code>.
+   * Creates a new "soft" instance of <code>{@link MoviePublicCategoryAssert}</code>.
    *
    * @param actual the actual value.
    * @return the created "soft" assertion object.
    */
   @org.assertj.core.util.CheckReturnValue
-  public org.assertj.assertions.generator.data.MoviePublicCategoryAssert then(org.assertj.assertions.generator.data.Movie.PublicCategory actual) {
-    return proxy(org.assertj.assertions.generator.data.MoviePublicCategoryAssert.class, org.assertj.assertions.generator.data.Movie.PublicCategory.class, actual);
+  public MoviePublicCategoryAssert then(Movie.PublicCategory actual) {
+    return proxy(MoviePublicCategoryAssert.class, Movie.PublicCategory.class, actual);
   }
 
   /**
-   * Creates a new "soft" instance of <code>{@link org.assertj.assertions.generator.data.NameAssert}</code>.
+   * Creates a new "soft" instance of <code>{@link NameAssert}</code>.
    *
    * @param actual the actual value.
    * @return the created "soft" assertion object.
    */
   @org.assertj.core.util.CheckReturnValue
-  public org.assertj.assertions.generator.data.NameAssert then(org.assertj.assertions.generator.data.Name actual) {
-    return proxy(org.assertj.assertions.generator.data.NameAssert.class, org.assertj.assertions.generator.data.Name.class, actual);
+  public NameAssert then(Name actual) {
+    return proxy(NameAssert.class, Name.class, actual);
   }
 
   /**
-   * Creates a new "soft" instance of <code>{@link org.assertj.assertions.generator.data.TreeEnumAssert}</code>.
+   * Creates a new "soft" instance of <code>{@link TreeEnumAssert}</code>.
    *
    * @param actual the actual value.
    * @return the created "soft" assertion object.
    */
   @org.assertj.core.util.CheckReturnValue
-  public org.assertj.assertions.generator.data.TreeEnumAssert then(org.assertj.assertions.generator.data.TreeEnum actual) {
-    return proxy(org.assertj.assertions.generator.data.TreeEnumAssert.class, org.assertj.assertions.generator.data.TreeEnum.class, actual);
+  public TreeEnumAssert then(TreeEnum actual) {
+    return proxy(TreeEnumAssert.class, TreeEnum.class, actual);
   }
 
   /**
-   * Creates a new "soft" instance of <code>{@link org.assertj.assertions.generator.data.lotr.RaceAssert}</code>.
+   * Creates a new "soft" instance of <code>{@link RaceAssert}</code>.
    *
    * @param actual the actual value.
    * @return the created "soft" assertion object.
    */
   @org.assertj.core.util.CheckReturnValue
-  public org.assertj.assertions.generator.data.lotr.RaceAssert then(org.assertj.assertions.generator.data.lotr.Race actual) {
-    return proxy(org.assertj.assertions.generator.data.lotr.RaceAssert.class, org.assertj.assertions.generator.data.lotr.Race.class, actual);
+  public RaceAssert then(Race actual) {
+    return proxy(RaceAssert.class, Race.class, actual);
   }
 
   /**
-   * Creates a new "soft" instance of <code>{@link org.assertj.assertions.generator.data.lotr.RingAssert}</code>.
+   * Creates a new "soft" instance of <code>{@link RingAssert}</code>.
    *
    * @param actual the actual value.
    * @return the created "soft" assertion object.
    */
   @org.assertj.core.util.CheckReturnValue
-  public org.assertj.assertions.generator.data.lotr.RingAssert then(org.assertj.assertions.generator.data.lotr.Ring actual) {
-    return proxy(org.assertj.assertions.generator.data.lotr.RingAssert.class, org.assertj.assertions.generator.data.lotr.Ring.class, actual);
+  public RingAssert then(Ring actual) {
+    return proxy(RingAssert.class, Ring.class, actual);
   }
 
   /**
-   * Creates a new "soft" instance of <code>{@link org.assertj.assertions.generator.data.lotr.TolkienCharacterAssert}</code>.
+   * Creates a new "soft" instance of <code>{@link TolkienCharacterAssert}</code>.
    *
    * @param actual the actual value.
    * @return the created "soft" assertion object.
    */
   @org.assertj.core.util.CheckReturnValue
-  public org.assertj.assertions.generator.data.lotr.TolkienCharacterAssert then(org.assertj.assertions.generator.data.lotr.TolkienCharacter actual) {
-    return proxy(org.assertj.assertions.generator.data.lotr.TolkienCharacterAssert.class, org.assertj.assertions.generator.data.lotr.TolkienCharacter.class, actual);
+  public TolkienCharacterAssert then(TolkienCharacter actual) {
+    return proxy(TolkienCharacterAssert.class, TolkienCharacter.class, actual);
   }
 
   /**
-   * Creates a new "soft" instance of <code>{@link org.assertj.assertions.generator.data.nba.PlayerAssert}</code>.
+   * Creates a new "soft" instance of <code>{@link PlayerAssert}</code>.
    *
    * @param actual the actual value.
    * @return the created "soft" assertion object.
    */
   @org.assertj.core.util.CheckReturnValue
-  public org.assertj.assertions.generator.data.nba.PlayerAssert then(org.assertj.assertions.generator.data.nba.Player actual) {
-    return proxy(org.assertj.assertions.generator.data.nba.PlayerAssert.class, org.assertj.assertions.generator.data.nba.Player.class, actual);
+  public PlayerAssert then(Player actual) {
+    return proxy(PlayerAssert.class, Player.class, actual);
   }
 
 }

--- a/src/test/resources/BddAssertions.expected.txt
+++ b/src/test/resources/BddAssertions.expected.txt
@@ -1,5 +1,23 @@
 package org.assertj.assertions.generator.data;
 
+import org.assertj.assertions.generator.data.ArtWork;
+import org.assertj.assertions.generator.data.ArtWorkAssert;
+import org.assertj.assertions.generator.data.Movie;
+import org.assertj.assertions.generator.data.MovieAssert;
+import org.assertj.assertions.generator.data.MoviePublicCategoryAssert;
+import org.assertj.assertions.generator.data.Name;
+import org.assertj.assertions.generator.data.NameAssert;
+import org.assertj.assertions.generator.data.TreeEnum;
+import org.assertj.assertions.generator.data.TreeEnumAssert;
+import org.assertj.assertions.generator.data.lotr.Race;
+import org.assertj.assertions.generator.data.lotr.RaceAssert;
+import org.assertj.assertions.generator.data.lotr.Ring;
+import org.assertj.assertions.generator.data.lotr.RingAssert;
+import org.assertj.assertions.generator.data.lotr.TolkienCharacter;
+import org.assertj.assertions.generator.data.lotr.TolkienCharacterAssert;
+import org.assertj.assertions.generator.data.nba.Player;
+import org.assertj.assertions.generator.data.nba.PlayerAssert;
+
 /**
  * Entry point for BDD assertions of different data types.
  */
@@ -7,102 +25,102 @@ package org.assertj.assertions.generator.data;
 public class BddAssertions {
 
   /**
-   * Creates a new instance of <code>{@link org.assertj.assertions.generator.data.ArtWorkAssert}</code>.
+   * Creates a new instance of <code>{@link ArtWorkAssert}</code>.
    *
    * @param actual the actual value.
    * @return the created assertion object.
    */
   @org.assertj.core.util.CheckReturnValue
-  public static org.assertj.assertions.generator.data.ArtWorkAssert then(org.assertj.assertions.generator.data.ArtWork actual) {
-    return new org.assertj.assertions.generator.data.ArtWorkAssert(actual);
+  public static ArtWorkAssert then(ArtWork actual) {
+    return new ArtWorkAssert(actual);
   }
 
   /**
-   * Creates a new instance of <code>{@link org.assertj.assertions.generator.data.MovieAssert}</code>.
+   * Creates a new instance of <code>{@link MovieAssert}</code>.
    *
    * @param actual the actual value.
    * @return the created assertion object.
    */
   @org.assertj.core.util.CheckReturnValue
-  public static org.assertj.assertions.generator.data.MovieAssert then(org.assertj.assertions.generator.data.Movie actual) {
-    return new org.assertj.assertions.generator.data.MovieAssert(actual);
+  public static MovieAssert then(Movie actual) {
+    return new MovieAssert(actual);
   }
 
   /**
-   * Creates a new instance of <code>{@link org.assertj.assertions.generator.data.MoviePublicCategoryAssert}</code>.
+   * Creates a new instance of <code>{@link MoviePublicCategoryAssert}</code>.
    *
    * @param actual the actual value.
    * @return the created assertion object.
    */
   @org.assertj.core.util.CheckReturnValue
-  public static org.assertj.assertions.generator.data.MoviePublicCategoryAssert then(org.assertj.assertions.generator.data.Movie.PublicCategory actual) {
-    return new org.assertj.assertions.generator.data.MoviePublicCategoryAssert(actual);
+  public static MoviePublicCategoryAssert then(Movie.PublicCategory actual) {
+    return new MoviePublicCategoryAssert(actual);
   }
 
   /**
-   * Creates a new instance of <code>{@link org.assertj.assertions.generator.data.NameAssert}</code>.
+   * Creates a new instance of <code>{@link NameAssert}</code>.
    *
    * @param actual the actual value.
    * @return the created assertion object.
    */
   @org.assertj.core.util.CheckReturnValue
-  public static org.assertj.assertions.generator.data.NameAssert then(org.assertj.assertions.generator.data.Name actual) {
-    return new org.assertj.assertions.generator.data.NameAssert(actual);
+  public static NameAssert then(Name actual) {
+    return new NameAssert(actual);
   }
 
   /**
-   * Creates a new instance of <code>{@link org.assertj.assertions.generator.data.TreeEnumAssert}</code>.
+   * Creates a new instance of <code>{@link TreeEnumAssert}</code>.
    *
    * @param actual the actual value.
    * @return the created assertion object.
    */
   @org.assertj.core.util.CheckReturnValue
-  public static org.assertj.assertions.generator.data.TreeEnumAssert then(org.assertj.assertions.generator.data.TreeEnum actual) {
-    return new org.assertj.assertions.generator.data.TreeEnumAssert(actual);
+  public static TreeEnumAssert then(TreeEnum actual) {
+    return new TreeEnumAssert(actual);
   }
 
   /**
-   * Creates a new instance of <code>{@link org.assertj.assertions.generator.data.lotr.RaceAssert}</code>.
+   * Creates a new instance of <code>{@link RaceAssert}</code>.
    *
    * @param actual the actual value.
    * @return the created assertion object.
    */
   @org.assertj.core.util.CheckReturnValue
-  public static org.assertj.assertions.generator.data.lotr.RaceAssert then(org.assertj.assertions.generator.data.lotr.Race actual) {
-    return new org.assertj.assertions.generator.data.lotr.RaceAssert(actual);
+  public static RaceAssert then(Race actual) {
+    return new RaceAssert(actual);
   }
 
   /**
-   * Creates a new instance of <code>{@link org.assertj.assertions.generator.data.lotr.RingAssert}</code>.
+   * Creates a new instance of <code>{@link RingAssert}</code>.
    *
    * @param actual the actual value.
    * @return the created assertion object.
    */
   @org.assertj.core.util.CheckReturnValue
-  public static org.assertj.assertions.generator.data.lotr.RingAssert then(org.assertj.assertions.generator.data.lotr.Ring actual) {
-    return new org.assertj.assertions.generator.data.lotr.RingAssert(actual);
+  public static RingAssert then(Ring actual) {
+    return new RingAssert(actual);
   }
 
   /**
-   * Creates a new instance of <code>{@link org.assertj.assertions.generator.data.lotr.TolkienCharacterAssert}</code>.
+   * Creates a new instance of <code>{@link TolkienCharacterAssert}</code>.
    *
    * @param actual the actual value.
    * @return the created assertion object.
    */
   @org.assertj.core.util.CheckReturnValue
-  public static org.assertj.assertions.generator.data.lotr.TolkienCharacterAssert then(org.assertj.assertions.generator.data.lotr.TolkienCharacter actual) {
-    return new org.assertj.assertions.generator.data.lotr.TolkienCharacterAssert(actual);
+  public static TolkienCharacterAssert then(TolkienCharacter actual) {
+    return new TolkienCharacterAssert(actual);
   }
 
   /**
-   * Creates a new instance of <code>{@link org.assertj.assertions.generator.data.nba.PlayerAssert}</code>.
+   * Creates a new instance of <code>{@link PlayerAssert}</code>.
    *
    * @param actual the actual value.
    * @return the created assertion object.
    */
   @org.assertj.core.util.CheckReturnValue
-  public static org.assertj.assertions.generator.data.nba.PlayerAssert then(org.assertj.assertions.generator.data.nba.Player actual) {
-    return new org.assertj.assertions.generator.data.nba.PlayerAssert(actual);
+  public static PlayerAssert then(Player actual) {
+    return new PlayerAssert(actual);
   }
 
   /**

--- a/src/test/resources/JUnitBDDSoftAssertions.expected.txt
+++ b/src/test/resources/JUnitBDDSoftAssertions.expected.txt
@@ -1,5 +1,23 @@
 package org.assertj.assertions.generator.data;
 
+import org.assertj.assertions.generator.data.ArtWork;
+import org.assertj.assertions.generator.data.ArtWorkAssert;
+import org.assertj.assertions.generator.data.Movie;
+import org.assertj.assertions.generator.data.MovieAssert;
+import org.assertj.assertions.generator.data.MoviePublicCategoryAssert;
+import org.assertj.assertions.generator.data.Name;
+import org.assertj.assertions.generator.data.NameAssert;
+import org.assertj.assertions.generator.data.TreeEnum;
+import org.assertj.assertions.generator.data.TreeEnumAssert;
+import org.assertj.assertions.generator.data.lotr.Race;
+import org.assertj.assertions.generator.data.lotr.RaceAssert;
+import org.assertj.assertions.generator.data.lotr.Ring;
+import org.assertj.assertions.generator.data.lotr.RingAssert;
+import org.assertj.assertions.generator.data.lotr.TolkienCharacter;
+import org.assertj.assertions.generator.data.lotr.TolkienCharacterAssert;
+import org.assertj.assertions.generator.data.nba.Player;
+import org.assertj.assertions.generator.data.nba.PlayerAssert;
+
 /**
  * Like {@link BDDSoftAssertions} but as a junit rule that takes care of calling
  * {@link SoftAssertions#assertAll() assertAll()} at the end of each test.
@@ -22,102 +40,102 @@ package org.assertj.assertions.generator.data;
 public class JUnitBDDSoftAssertions extends org.assertj.core.api.JUnitBDDSoftAssertions {
 
   /**
-   * Creates a new "soft" instance of <code>{@link org.assertj.assertions.generator.data.ArtWorkAssert}</code>.
+   * Creates a new "soft" instance of <code>{@link ArtWorkAssert}</code>.
    *
    * @param actual the actual value.
    * @return the created "soft" assertion object.
    */
   @org.assertj.core.util.CheckReturnValue
-  public org.assertj.assertions.generator.data.ArtWorkAssert then(org.assertj.assertions.generator.data.ArtWork actual) {
-    return proxy(org.assertj.assertions.generator.data.ArtWorkAssert.class, org.assertj.assertions.generator.data.ArtWork.class, actual);
+  public ArtWorkAssert then(ArtWork actual) {
+    return proxy(ArtWorkAssert.class, ArtWork.class, actual);
   }
 
   /**
-   * Creates a new "soft" instance of <code>{@link org.assertj.assertions.generator.data.MovieAssert}</code>.
+   * Creates a new "soft" instance of <code>{@link MovieAssert}</code>.
    *
    * @param actual the actual value.
    * @return the created "soft" assertion object.
    */
   @org.assertj.core.util.CheckReturnValue
-  public org.assertj.assertions.generator.data.MovieAssert then(org.assertj.assertions.generator.data.Movie actual) {
-    return proxy(org.assertj.assertions.generator.data.MovieAssert.class, org.assertj.assertions.generator.data.Movie.class, actual);
+  public MovieAssert then(Movie actual) {
+    return proxy(MovieAssert.class, Movie.class, actual);
   }
 
   /**
-   * Creates a new "soft" instance of <code>{@link org.assertj.assertions.generator.data.MoviePublicCategoryAssert}</code>.
+   * Creates a new "soft" instance of <code>{@link MoviePublicCategoryAssert}</code>.
    *
    * @param actual the actual value.
    * @return the created "soft" assertion object.
    */
   @org.assertj.core.util.CheckReturnValue
-  public org.assertj.assertions.generator.data.MoviePublicCategoryAssert then(org.assertj.assertions.generator.data.Movie.PublicCategory actual) {
-    return proxy(org.assertj.assertions.generator.data.MoviePublicCategoryAssert.class, org.assertj.assertions.generator.data.Movie.PublicCategory.class, actual);
+  public MoviePublicCategoryAssert then(Movie.PublicCategory actual) {
+    return proxy(MoviePublicCategoryAssert.class, Movie.PublicCategory.class, actual);
   }
 
   /**
-   * Creates a new "soft" instance of <code>{@link org.assertj.assertions.generator.data.NameAssert}</code>.
+   * Creates a new "soft" instance of <code>{@link NameAssert}</code>.
    *
    * @param actual the actual value.
    * @return the created "soft" assertion object.
    */
   @org.assertj.core.util.CheckReturnValue
-  public org.assertj.assertions.generator.data.NameAssert then(org.assertj.assertions.generator.data.Name actual) {
-    return proxy(org.assertj.assertions.generator.data.NameAssert.class, org.assertj.assertions.generator.data.Name.class, actual);
+  public NameAssert then(Name actual) {
+    return proxy(NameAssert.class, Name.class, actual);
   }
 
   /**
-   * Creates a new "soft" instance of <code>{@link org.assertj.assertions.generator.data.TreeEnumAssert}</code>.
+   * Creates a new "soft" instance of <code>{@link TreeEnumAssert}</code>.
    *
    * @param actual the actual value.
    * @return the created "soft" assertion object.
    */
   @org.assertj.core.util.CheckReturnValue
-  public org.assertj.assertions.generator.data.TreeEnumAssert then(org.assertj.assertions.generator.data.TreeEnum actual) {
-    return proxy(org.assertj.assertions.generator.data.TreeEnumAssert.class, org.assertj.assertions.generator.data.TreeEnum.class, actual);
+  public TreeEnumAssert then(TreeEnum actual) {
+    return proxy(TreeEnumAssert.class, TreeEnum.class, actual);
   }
 
   /**
-   * Creates a new "soft" instance of <code>{@link org.assertj.assertions.generator.data.lotr.RaceAssert}</code>.
+   * Creates a new "soft" instance of <code>{@link RaceAssert}</code>.
    *
    * @param actual the actual value.
    * @return the created "soft" assertion object.
    */
   @org.assertj.core.util.CheckReturnValue
-  public org.assertj.assertions.generator.data.lotr.RaceAssert then(org.assertj.assertions.generator.data.lotr.Race actual) {
-    return proxy(org.assertj.assertions.generator.data.lotr.RaceAssert.class, org.assertj.assertions.generator.data.lotr.Race.class, actual);
+  public RaceAssert then(Race actual) {
+    return proxy(RaceAssert.class, Race.class, actual);
   }
 
   /**
-   * Creates a new "soft" instance of <code>{@link org.assertj.assertions.generator.data.lotr.RingAssert}</code>.
+   * Creates a new "soft" instance of <code>{@link RingAssert}</code>.
    *
    * @param actual the actual value.
    * @return the created "soft" assertion object.
    */
   @org.assertj.core.util.CheckReturnValue
-  public org.assertj.assertions.generator.data.lotr.RingAssert then(org.assertj.assertions.generator.data.lotr.Ring actual) {
-    return proxy(org.assertj.assertions.generator.data.lotr.RingAssert.class, org.assertj.assertions.generator.data.lotr.Ring.class, actual);
+  public RingAssert then(Ring actual) {
+    return proxy(RingAssert.class, Ring.class, actual);
   }
 
   /**
-   * Creates a new "soft" instance of <code>{@link org.assertj.assertions.generator.data.lotr.TolkienCharacterAssert}</code>.
+   * Creates a new "soft" instance of <code>{@link TolkienCharacterAssert}</code>.
    *
    * @param actual the actual value.
    * @return the created "soft" assertion object.
    */
   @org.assertj.core.util.CheckReturnValue
-  public org.assertj.assertions.generator.data.lotr.TolkienCharacterAssert then(org.assertj.assertions.generator.data.lotr.TolkienCharacter actual) {
-    return proxy(org.assertj.assertions.generator.data.lotr.TolkienCharacterAssert.class, org.assertj.assertions.generator.data.lotr.TolkienCharacter.class, actual);
+  public TolkienCharacterAssert then(TolkienCharacter actual) {
+    return proxy(TolkienCharacterAssert.class, TolkienCharacter.class, actual);
   }
 
   /**
-   * Creates a new "soft" instance of <code>{@link org.assertj.assertions.generator.data.nba.PlayerAssert}</code>.
+   * Creates a new "soft" instance of <code>{@link PlayerAssert}</code>.
    *
    * @param actual the actual value.
    * @return the created "soft" assertion object.
    */
   @org.assertj.core.util.CheckReturnValue
-  public org.assertj.assertions.generator.data.nba.PlayerAssert then(org.assertj.assertions.generator.data.nba.Player actual) {
-    return proxy(org.assertj.assertions.generator.data.nba.PlayerAssert.class, org.assertj.assertions.generator.data.nba.Player.class, actual);
+  public PlayerAssert then(Player actual) {
+    return proxy(PlayerAssert.class, Player.class, actual);
   }
 
 }

--- a/src/test/resources/JUnitSoftAssertions.expected.txt
+++ b/src/test/resources/JUnitSoftAssertions.expected.txt
@@ -1,5 +1,23 @@
 package org.assertj.assertions.generator.data;
 
+import org.assertj.assertions.generator.data.ArtWork;
+import org.assertj.assertions.generator.data.ArtWorkAssert;
+import org.assertj.assertions.generator.data.Movie;
+import org.assertj.assertions.generator.data.MovieAssert;
+import org.assertj.assertions.generator.data.MoviePublicCategoryAssert;
+import org.assertj.assertions.generator.data.Name;
+import org.assertj.assertions.generator.data.NameAssert;
+import org.assertj.assertions.generator.data.TreeEnum;
+import org.assertj.assertions.generator.data.TreeEnumAssert;
+import org.assertj.assertions.generator.data.lotr.Race;
+import org.assertj.assertions.generator.data.lotr.RaceAssert;
+import org.assertj.assertions.generator.data.lotr.Ring;
+import org.assertj.assertions.generator.data.lotr.RingAssert;
+import org.assertj.assertions.generator.data.lotr.TolkienCharacter;
+import org.assertj.assertions.generator.data.lotr.TolkienCharacterAssert;
+import org.assertj.assertions.generator.data.nba.Player;
+import org.assertj.assertions.generator.data.nba.PlayerAssert;
+
 /**
  * Like {@link SoftAssertions} but as a junit rule that takes care of calling
  * {@link SoftAssertions#assertAll() assertAll()} at the end of each test.
@@ -22,102 +40,102 @@ package org.assertj.assertions.generator.data;
 public class JUnitSoftAssertions extends org.assertj.core.api.JUnitSoftAssertions {
 
   /**
-   * Creates a new "soft" instance of <code>{@link org.assertj.assertions.generator.data.ArtWorkAssert}</code>.
+   * Creates a new "soft" instance of <code>{@link ArtWorkAssert}</code>.
    *
    * @param actual the actual value.
    * @return the created "soft" assertion object.
    */
   @org.assertj.core.util.CheckReturnValue
-  public org.assertj.assertions.generator.data.ArtWorkAssert assertThat(org.assertj.assertions.generator.data.ArtWork actual) {
-    return proxy(org.assertj.assertions.generator.data.ArtWorkAssert.class, org.assertj.assertions.generator.data.ArtWork.class, actual);
+  public ArtWorkAssert assertThat(ArtWork actual) {
+    return proxy(ArtWorkAssert.class, ArtWork.class, actual);
   }
 
   /**
-   * Creates a new "soft" instance of <code>{@link org.assertj.assertions.generator.data.MovieAssert}</code>.
+   * Creates a new "soft" instance of <code>{@link MovieAssert}</code>.
    *
    * @param actual the actual value.
    * @return the created "soft" assertion object.
    */
   @org.assertj.core.util.CheckReturnValue
-  public org.assertj.assertions.generator.data.MovieAssert assertThat(org.assertj.assertions.generator.data.Movie actual) {
-    return proxy(org.assertj.assertions.generator.data.MovieAssert.class, org.assertj.assertions.generator.data.Movie.class, actual);
+  public MovieAssert assertThat(Movie actual) {
+    return proxy(MovieAssert.class, Movie.class, actual);
   }
 
   /**
-   * Creates a new "soft" instance of <code>{@link org.assertj.assertions.generator.data.MoviePublicCategoryAssert}</code>.
+   * Creates a new "soft" instance of <code>{@link MoviePublicCategoryAssert}</code>.
    *
    * @param actual the actual value.
    * @return the created "soft" assertion object.
    */
   @org.assertj.core.util.CheckReturnValue
-  public org.assertj.assertions.generator.data.MoviePublicCategoryAssert assertThat(org.assertj.assertions.generator.data.Movie.PublicCategory actual) {
-    return proxy(org.assertj.assertions.generator.data.MoviePublicCategoryAssert.class, org.assertj.assertions.generator.data.Movie.PublicCategory.class, actual);
+  public MoviePublicCategoryAssert assertThat(Movie.PublicCategory actual) {
+    return proxy(MoviePublicCategoryAssert.class, Movie.PublicCategory.class, actual);
   }
 
   /**
-   * Creates a new "soft" instance of <code>{@link org.assertj.assertions.generator.data.NameAssert}</code>.
+   * Creates a new "soft" instance of <code>{@link NameAssert}</code>.
    *
    * @param actual the actual value.
    * @return the created "soft" assertion object.
    */
   @org.assertj.core.util.CheckReturnValue
-  public org.assertj.assertions.generator.data.NameAssert assertThat(org.assertj.assertions.generator.data.Name actual) {
-    return proxy(org.assertj.assertions.generator.data.NameAssert.class, org.assertj.assertions.generator.data.Name.class, actual);
+  public NameAssert assertThat(Name actual) {
+    return proxy(NameAssert.class, Name.class, actual);
   }
 
   /**
-   * Creates a new "soft" instance of <code>{@link org.assertj.assertions.generator.data.TreeEnumAssert}</code>.
+   * Creates a new "soft" instance of <code>{@link TreeEnumAssert}</code>.
    *
    * @param actual the actual value.
    * @return the created "soft" assertion object.
    */
   @org.assertj.core.util.CheckReturnValue
-  public org.assertj.assertions.generator.data.TreeEnumAssert assertThat(org.assertj.assertions.generator.data.TreeEnum actual) {
-    return proxy(org.assertj.assertions.generator.data.TreeEnumAssert.class, org.assertj.assertions.generator.data.TreeEnum.class, actual);
+  public TreeEnumAssert assertThat(TreeEnum actual) {
+    return proxy(TreeEnumAssert.class, TreeEnum.class, actual);
   }
 
   /**
-   * Creates a new "soft" instance of <code>{@link org.assertj.assertions.generator.data.lotr.RaceAssert}</code>.
+   * Creates a new "soft" instance of <code>{@link RaceAssert}</code>.
    *
    * @param actual the actual value.
    * @return the created "soft" assertion object.
    */
   @org.assertj.core.util.CheckReturnValue
-  public org.assertj.assertions.generator.data.lotr.RaceAssert assertThat(org.assertj.assertions.generator.data.lotr.Race actual) {
-    return proxy(org.assertj.assertions.generator.data.lotr.RaceAssert.class, org.assertj.assertions.generator.data.lotr.Race.class, actual);
+  public RaceAssert assertThat(Race actual) {
+    return proxy(RaceAssert.class, Race.class, actual);
   }
 
   /**
-   * Creates a new "soft" instance of <code>{@link org.assertj.assertions.generator.data.lotr.RingAssert}</code>.
+   * Creates a new "soft" instance of <code>{@link RingAssert}</code>.
    *
    * @param actual the actual value.
    * @return the created "soft" assertion object.
    */
   @org.assertj.core.util.CheckReturnValue
-  public org.assertj.assertions.generator.data.lotr.RingAssert assertThat(org.assertj.assertions.generator.data.lotr.Ring actual) {
-    return proxy(org.assertj.assertions.generator.data.lotr.RingAssert.class, org.assertj.assertions.generator.data.lotr.Ring.class, actual);
+  public RingAssert assertThat(Ring actual) {
+    return proxy(RingAssert.class, Ring.class, actual);
   }
 
   /**
-   * Creates a new "soft" instance of <code>{@link org.assertj.assertions.generator.data.lotr.TolkienCharacterAssert}</code>.
+   * Creates a new "soft" instance of <code>{@link TolkienCharacterAssert}</code>.
    *
    * @param actual the actual value.
    * @return the created "soft" assertion object.
    */
   @org.assertj.core.util.CheckReturnValue
-  public org.assertj.assertions.generator.data.lotr.TolkienCharacterAssert assertThat(org.assertj.assertions.generator.data.lotr.TolkienCharacter actual) {
-    return proxy(org.assertj.assertions.generator.data.lotr.TolkienCharacterAssert.class, org.assertj.assertions.generator.data.lotr.TolkienCharacter.class, actual);
+  public TolkienCharacterAssert assertThat(TolkienCharacter actual) {
+    return proxy(TolkienCharacterAssert.class, TolkienCharacter.class, actual);
   }
 
   /**
-   * Creates a new "soft" instance of <code>{@link org.assertj.assertions.generator.data.nba.PlayerAssert}</code>.
+   * Creates a new "soft" instance of <code>{@link PlayerAssert}</code>.
    *
    * @param actual the actual value.
    * @return the created "soft" assertion object.
    */
   @org.assertj.core.util.CheckReturnValue
-  public org.assertj.assertions.generator.data.nba.PlayerAssert assertThat(org.assertj.assertions.generator.data.nba.Player actual) {
-    return proxy(org.assertj.assertions.generator.data.nba.PlayerAssert.class, org.assertj.assertions.generator.data.nba.Player.class, actual);
+  public PlayerAssert assertThat(Player actual) {
+    return proxy(PlayerAssert.class, Player.class, actual);
   }
 
 }

--- a/src/test/resources/MyAssertions.expected.txt
+++ b/src/test/resources/MyAssertions.expected.txt
@@ -1,5 +1,8 @@
 package org.assertj.assertions.generator.data.lotr;
 
+import org.assertj.assertions.generator.data.lotr.Ring;
+import org.assertj.assertions.generator.data.lotr.RingAssert;
+
 /**
  * Entry point for assertions of different data types. Each method in this class is a static factory for the
  * type-specific assertion objects.
@@ -8,14 +11,14 @@ package org.assertj.assertions.generator.data.lotr;
 public class MyAssertions {
 
   /**
-   * Creates a new instance of <code>{@link org.assertj.assertions.generator.data.lotr.RingAssert}</code>.
+   * Creates a new instance of <code>{@link RingAssert}</code>.
    *
    * @param actual the actual value.
    * @return the created assertion object.
    */
   @org.assertj.core.util.CheckReturnValue
-  public static org.assertj.assertions.generator.data.lotr.RingAssert assertThat(org.assertj.assertions.generator.data.lotr.Ring actual) {
-    return new org.assertj.assertions.generator.data.lotr.RingAssert(actual);
+  public static RingAssert assertThat(Ring actual) {
+    return new RingAssert(actual);
   }
 
   /**

--- a/src/test/resources/SoftAssertions.expected.txt
+++ b/src/test/resources/SoftAssertions.expected.txt
@@ -1,5 +1,23 @@
 package org.assertj.assertions.generator.data;
 
+import org.assertj.assertions.generator.data.ArtWork;
+import org.assertj.assertions.generator.data.ArtWorkAssert;
+import org.assertj.assertions.generator.data.Movie;
+import org.assertj.assertions.generator.data.MovieAssert;
+import org.assertj.assertions.generator.data.MoviePublicCategoryAssert;
+import org.assertj.assertions.generator.data.Name;
+import org.assertj.assertions.generator.data.NameAssert;
+import org.assertj.assertions.generator.data.TreeEnum;
+import org.assertj.assertions.generator.data.TreeEnumAssert;
+import org.assertj.assertions.generator.data.lotr.Race;
+import org.assertj.assertions.generator.data.lotr.RaceAssert;
+import org.assertj.assertions.generator.data.lotr.Ring;
+import org.assertj.assertions.generator.data.lotr.RingAssert;
+import org.assertj.assertions.generator.data.lotr.TolkienCharacter;
+import org.assertj.assertions.generator.data.lotr.TolkienCharacterAssert;
+import org.assertj.assertions.generator.data.nba.Player;
+import org.assertj.assertions.generator.data.nba.PlayerAssert;
+
 /**
  * Entry point for soft assertions of different data types.
  */
@@ -7,102 +25,102 @@ package org.assertj.assertions.generator.data;
 public class SoftAssertions extends org.assertj.core.api.SoftAssertions {
 
   /**
-   * Creates a new "soft" instance of <code>{@link org.assertj.assertions.generator.data.ArtWorkAssert}</code>.
+   * Creates a new "soft" instance of <code>{@link ArtWorkAssert}</code>.
    *
    * @param actual the actual value.
    * @return the created "soft" assertion object.
    */
   @org.assertj.core.util.CheckReturnValue
-  public org.assertj.assertions.generator.data.ArtWorkAssert assertThat(org.assertj.assertions.generator.data.ArtWork actual) {
-    return proxy(org.assertj.assertions.generator.data.ArtWorkAssert.class, org.assertj.assertions.generator.data.ArtWork.class, actual);
+  public ArtWorkAssert assertThat(ArtWork actual) {
+    return proxy(ArtWorkAssert.class, ArtWork.class, actual);
   }
 
   /**
-   * Creates a new "soft" instance of <code>{@link org.assertj.assertions.generator.data.MovieAssert}</code>.
+   * Creates a new "soft" instance of <code>{@link MovieAssert}</code>.
    *
    * @param actual the actual value.
    * @return the created "soft" assertion object.
    */
   @org.assertj.core.util.CheckReturnValue
-  public org.assertj.assertions.generator.data.MovieAssert assertThat(org.assertj.assertions.generator.data.Movie actual) {
-    return proxy(org.assertj.assertions.generator.data.MovieAssert.class, org.assertj.assertions.generator.data.Movie.class, actual);
+  public MovieAssert assertThat(Movie actual) {
+    return proxy(MovieAssert.class, Movie.class, actual);
   }
 
   /**
-   * Creates a new "soft" instance of <code>{@link org.assertj.assertions.generator.data.MoviePublicCategoryAssert}</code>.
+   * Creates a new "soft" instance of <code>{@link MoviePublicCategoryAssert}</code>.
    *
    * @param actual the actual value.
    * @return the created "soft" assertion object.
    */
   @org.assertj.core.util.CheckReturnValue
-  public org.assertj.assertions.generator.data.MoviePublicCategoryAssert assertThat(org.assertj.assertions.generator.data.Movie.PublicCategory actual) {
-    return proxy(org.assertj.assertions.generator.data.MoviePublicCategoryAssert.class, org.assertj.assertions.generator.data.Movie.PublicCategory.class, actual);
+  public MoviePublicCategoryAssert assertThat(Movie.PublicCategory actual) {
+    return proxy(MoviePublicCategoryAssert.class, Movie.PublicCategory.class, actual);
   }
 
   /**
-   * Creates a new "soft" instance of <code>{@link org.assertj.assertions.generator.data.NameAssert}</code>.
+   * Creates a new "soft" instance of <code>{@link NameAssert}</code>.
    *
    * @param actual the actual value.
    * @return the created "soft" assertion object.
    */
   @org.assertj.core.util.CheckReturnValue
-  public org.assertj.assertions.generator.data.NameAssert assertThat(org.assertj.assertions.generator.data.Name actual) {
-    return proxy(org.assertj.assertions.generator.data.NameAssert.class, org.assertj.assertions.generator.data.Name.class, actual);
+  public NameAssert assertThat(Name actual) {
+    return proxy(NameAssert.class, Name.class, actual);
   }
 
   /**
-   * Creates a new "soft" instance of <code>{@link org.assertj.assertions.generator.data.TreeEnumAssert}</code>.
+   * Creates a new "soft" instance of <code>{@link TreeEnumAssert}</code>.
    *
    * @param actual the actual value.
    * @return the created "soft" assertion object.
    */
   @org.assertj.core.util.CheckReturnValue
-  public org.assertj.assertions.generator.data.TreeEnumAssert assertThat(org.assertj.assertions.generator.data.TreeEnum actual) {
-    return proxy(org.assertj.assertions.generator.data.TreeEnumAssert.class, org.assertj.assertions.generator.data.TreeEnum.class, actual);
+  public TreeEnumAssert assertThat(TreeEnum actual) {
+    return proxy(TreeEnumAssert.class, TreeEnum.class, actual);
   }
 
   /**
-   * Creates a new "soft" instance of <code>{@link org.assertj.assertions.generator.data.lotr.RaceAssert}</code>.
+   * Creates a new "soft" instance of <code>{@link RaceAssert}</code>.
    *
    * @param actual the actual value.
    * @return the created "soft" assertion object.
    */
   @org.assertj.core.util.CheckReturnValue
-  public org.assertj.assertions.generator.data.lotr.RaceAssert assertThat(org.assertj.assertions.generator.data.lotr.Race actual) {
-    return proxy(org.assertj.assertions.generator.data.lotr.RaceAssert.class, org.assertj.assertions.generator.data.lotr.Race.class, actual);
+  public RaceAssert assertThat(Race actual) {
+    return proxy(RaceAssert.class, Race.class, actual);
   }
 
   /**
-   * Creates a new "soft" instance of <code>{@link org.assertj.assertions.generator.data.lotr.RingAssert}</code>.
+   * Creates a new "soft" instance of <code>{@link RingAssert}</code>.
    *
    * @param actual the actual value.
    * @return the created "soft" assertion object.
    */
   @org.assertj.core.util.CheckReturnValue
-  public org.assertj.assertions.generator.data.lotr.RingAssert assertThat(org.assertj.assertions.generator.data.lotr.Ring actual) {
-    return proxy(org.assertj.assertions.generator.data.lotr.RingAssert.class, org.assertj.assertions.generator.data.lotr.Ring.class, actual);
+  public RingAssert assertThat(Ring actual) {
+    return proxy(RingAssert.class, Ring.class, actual);
   }
 
   /**
-   * Creates a new "soft" instance of <code>{@link org.assertj.assertions.generator.data.lotr.TolkienCharacterAssert}</code>.
+   * Creates a new "soft" instance of <code>{@link TolkienCharacterAssert}</code>.
    *
    * @param actual the actual value.
    * @return the created "soft" assertion object.
    */
   @org.assertj.core.util.CheckReturnValue
-  public org.assertj.assertions.generator.data.lotr.TolkienCharacterAssert assertThat(org.assertj.assertions.generator.data.lotr.TolkienCharacter actual) {
-    return proxy(org.assertj.assertions.generator.data.lotr.TolkienCharacterAssert.class, org.assertj.assertions.generator.data.lotr.TolkienCharacter.class, actual);
+  public TolkienCharacterAssert assertThat(TolkienCharacter actual) {
+    return proxy(TolkienCharacterAssert.class, TolkienCharacter.class, actual);
   }
 
   /**
-   * Creates a new "soft" instance of <code>{@link org.assertj.assertions.generator.data.nba.PlayerAssert}</code>.
+   * Creates a new "soft" instance of <code>{@link PlayerAssert}</code>.
    *
    * @param actual the actual value.
    * @return the created "soft" assertion object.
    */
   @org.assertj.core.util.CheckReturnValue
-  public org.assertj.assertions.generator.data.nba.PlayerAssert assertThat(org.assertj.assertions.generator.data.nba.Player actual) {
-    return proxy(org.assertj.assertions.generator.data.nba.PlayerAssert.class, org.assertj.assertions.generator.data.nba.Player.class, actual);
+  public PlayerAssert assertThat(Player actual) {
+    return proxy(PlayerAssert.class, Player.class, actual);
   }
 
 }

--- a/src/test/resources/customtemplates/my_assertion_entry_point_class.txt
+++ b/src/test/resources/customtemplates/my_assertion_entry_point_class.txt
@@ -1,5 +1,6 @@
 package ${package};
 
+${imports}
 /**
  * Entry point for assertions of different data types. Each method in this class is a static factory for the
  * type-specific assertion objects.


### PR DESCRIPTION
Fixes #97 

This is a first go in trying to use imports instead of using FQN in the assertions class.

I am not sure if this is complete:

* Maybe do a check if the entry point is in the same location as the assert class and the domain object
* I was thinking that it might be good to add this as a configuration to the generator, so someone can turn it off until we are sure that it works ok. However, I saw that currently this is done on the caller side and not in the generator (for hiearchical for example)