### PR TITLE
Use CodeCov instead of SonarQube in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,6 +41,4 @@ jobs:
         env:
           JAVA_VERSION: ${{ matrix.java_version }}
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          flags: current
           env_vars: JAVA_VERSION

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,26 +13,34 @@ jobs:
 
     runs-on: ubuntu-latest
     if: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}
+    strategy:
+      fail-fast: true
+      matrix:
+        java_version: [ 8 ]
 
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 1.8
+      - name: Set up JDK ${{ matrix.java_version }}
         uses: actions/setup-java@v1
         with:
-          java-version: 1.8
+          java-version: ${{ matrix.java_version }}
+
       - name: Cache Maven Repository
         uses: actions/cache@v2
         with:
           path: ~/.m2
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-maven
-      - name: Test with Sonar
-        run: >
-          ./mvnw -V --no-transfer-progress -e clean verify javadoc:javadoc
-          org.sonarsource.scanner.maven:sonar-maven-plugin:3.7.0.1746:sonar
-          -Dsonar.host.url=https://sonarcloud.io
-          -Dsonar.organization=assertj
-          -Dsonar.projectKey=assertj_assertj-assertions-generator
+
+      - name: Build with Maven
+        run: ./mvnw -V --no-transfer-progress -e clean verify javadoc:javadoc
+          
+
+      - name: Upload build code coverage
+        uses: codecov/codecov-action@v1
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          JAVA_VERSION: ${{ matrix.java_version }}
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          flags: current
+          env_vars: JAVA_VERSION

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 ![CI](https://github.com/assertj/assertj-assertions-generator/workflows/CI/badge.svg)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.assertj/assertj-assertions-generator-maven-plugin/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.assertj/assertj-assertions-generator-maven-plugin)
+[![codecov](https://codecov.io/gh/szatyinadam/assertj-assertions-generator/branch/main/graph/badge.svg?token=T0OTMN3AMY)](https://codecov.io/gh/szatyinadam/assertj-assertions-generator)
 
 ## Overview 
 


### PR DESCRIPTION
This PR is trying to fix #140 .

I've changed the CI process to use CodeCov code analysis instead of SonarQube.

Changed the Java setup to matrix as well, so we will be able to easily add 11 to the matrix, when to project can be compiled with Java 11 (I think we should add javax.annotation as a dependency and resolve some ClassLoader issues to make this happen).

I leave my test CodeCov account URL in the README.md's badge URL, but __this should be changed to the correct URL before merge__ (this is the reason this PR is is Draft stage, please respond with the URL generated on the project's CodeCov account).


