### PR TITLE
Fix assertions being generated for bridge methods instead of actual getter method

### DIFF
--- a/assertj-generator/src/main/java/org/assertj/assertions/generator/util/ClassUtil.java
+++ b/assertj-generator/src/main/java/org/assertj/assertions/generator/util/ClassUtil.java
@@ -463,12 +463,13 @@ public class ClassUtil {
     return filterGetterMethods(clazz.getMethods(), includeAnnotations, isClassAnnotated);
   }
 
-  private static Set<Method> filterGetterMethods(Method[] methods, Set<Class<?>> includeAnnotations,
+  static Set<Method> filterGetterMethods(Method[] methods, Set<Class<?>> includeAnnotations,
                                                  boolean isClassAnnotated) {
     Set<Method> getters = new TreeSet<>(GETTER_COMPARATOR);
     for (Method method : methods) {
       if (isPublic(method.getModifiers())
           && isNotDefinedInObjectClass(method)
+          && !method.isBridge()
           && isGetter(method, includeAnnotations, isClassAnnotated)) {
         getters.add(method);
       }

--- a/assertj-generator/src/test/java/org/assertj/assertions/generator/util/ClassUtilTest.java
+++ b/assertj-generator/src/test/java/org/assertj/assertions/generator/util/ClassUtilTest.java
@@ -288,11 +288,11 @@ class ClassUtilTest implements NestedClassesTest {
     Method[] methodsActualFirst = new Method[] { actualGetter, bridgeGetter };
     Method[] methodsBridgeFirst = new Method[] { bridgeGetter, actualGetter };
 
-    assertThat(filterGetterMethods(methodsActualFirst, Collections.emptySet(), false))
-      .singleElement().extracting(Method::getReturnType).isEqualTo(String.class);
+    Set<Method> getterMethods1 = filterGetterMethods(methodsActualFirst, Collections.emptySet(), false);
+    assertThat(getterMethods1).singleElement().extracting(Method::getReturnType).isEqualTo(String.class);
 
-    assertThat(filterGetterMethods(methodsBridgeFirst, Collections.emptySet(), false))
-      .singleElement().extracting(Method::getReturnType).isEqualTo(String.class);
+    Set<Method> getterMethods2 = filterGetterMethods(methodsBridgeFirst, Collections.emptySet(), false);
+    assertThat(getterMethods2).singleElement().extracting(Method::getReturnType).isEqualTo(String.class);
   }
 
   @ParameterizedTest

--- a/assertj-generator/src/test/java/org/assertj/assertions/generator/util/ClassUtilTest.java
+++ b/assertj-generator/src/test/java/org/assertj/assertions/generator/util/ClassUtilTest.java
@@ -50,11 +50,13 @@ import org.junit.jupiter.params.provider.FieldSource;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.ParameterizedType;
+import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
+import java.util.function.Predicate;
 
 import static java.util.Arrays.asList;
 import static org.assertj.assertions.generator.util.ClassUtil.collectClasses;
@@ -77,6 +79,7 @@ import static org.assertj.assertions.generator.util.ClassUtil.isValidGetterName;
 import static org.assertj.assertions.generator.util.ClassUtil.propertyNameOf;
 import static org.assertj.assertions.generator.util.ClassUtil.resolveTypeNameInPackage;
 import static org.assertj.assertions.generator.util.ClassUtil.visibilityOf;
+import static org.assertj.assertions.generator.util.ClassUtil.filterGetterMethods;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 
@@ -276,6 +279,22 @@ class ClassUtilTest implements NestedClassesTest {
       assertThat(getterProperty("get")).isEqualTo("get");
   }
 
+  @Test
+  void should_not_return_getter_bridge_methods() throws Exception {
+    Method[] methods = ConcreteClass.class.getDeclaredMethods();
+    Method actualGetter = Arrays.stream(methods).filter(Predicate.not(Method::isBridge)).findFirst().orElseThrow();
+    Method bridgeGetter = Arrays.stream(methods).filter(Method::isBridge).findFirst().orElseThrow();
+
+    Method[] methodsActualFirst = new Method[] { actualGetter, bridgeGetter };
+    Method[] methodsBridgeFirst = new Method[] { bridgeGetter, actualGetter };
+
+    assertThat(filterGetterMethods(methodsActualFirst, Collections.emptySet(), false))
+      .singleElement().extracting(Method::getReturnType).isEqualTo(String.class);
+
+    assertThat(filterGetterMethods(methodsBridgeFirst, Collections.emptySet(), false))
+      .singleElement().extracting(Method::getReturnType).isEqualTo(String.class);
+  }
+
   @ParameterizedTest
   @FieldSource("NESTED_CLASSES")
   void should_return_inner_class_name_with_outer_class_name(NestedClass nestedClass) {
@@ -473,6 +492,16 @@ class ClassUtilTest implements NestedClassesTest {
     }
 
     public <T extends Number> T getNumber() {
+      return null;
+    }
+  }
+
+  private static abstract class AbstractClassWithGeneric<T extends Object> {
+    public abstract T getValue();
+  }
+  private static class ConcreteClass extends AbstractClassWithGeneric<String> {
+    @Override
+    public String getValue() {
       return null;
     }
   }


### PR DESCRIPTION
## Problem

When generating assertions for getter methods, the AssertJ generator creates a single `GetterDescription` per getter name. The description is currently derived from the first method returned by `Class#getMethods()` or `Class#getDeclaredMethods()`.

In most cases this works as expected. However, it becomes problematic for classes that contain compiler-generated bridge methods, for example:

```java
private static abstract class AbstractClassWithGeneric<T> {
  public abstract T getValue();
}

private static class ConcreteClass extends AbstractClassWithGeneric<String> {
  @Override
  public String getValue() {
    return null;
  }
}
```

For `ConcreteClass`, the compiler generates two methods named `getValue()`:

* `String getValue()` (the actual implementation)
* `Object getValue()` (a synthetic bridge method)

The Java Reflection API does not guarantee the order of methods returned by `Class#getDeclaredMethods()` or `Class#getMethods()`. As a result, the generator may pick either method when building the `GetterDescription`.

This can lead to non-deterministic output, generating either `hasValue(String value)` or `hasValue(Object value)` depending on the method order returned at runtime. Consequently, the generated assertion files may change between executions of the generator even when the source code itself has not changed.

## Solution
This PR excludes bridge methods when collecting getter descriptions. This ensures that the generator consistently uses the actual getter implementation and produces deterministic assertion methods.